### PR TITLE
deps: update wgpu to 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,15 +106,15 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
 
 [[package]]
 name = "ash"
-version = "0.32.1"
+version = "0.33.3+1.2.191"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06063a002a77d2734631db74e8f4ce7148b77fe522e6bca46f2ae7774fd48112"
+checksum = "cc4f1d82f164f838ae413296d1131aa6fa79b917d25bebaa7033d25620c09219"
 dependencies = [
  "libloading 0.7.0",
 ]
@@ -712,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "d3d12"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091ed1b25fe47c7ff129fc440c23650b6114f36aa00bc7212cc8041879294428"
+checksum = "2daefd788d1e96e0a9d66dee4b828b883509bc3ea9ce30665f04c3246372690c"
 dependencies = [
  "bitflags",
  "libloading 0.7.0",
@@ -814,15 +814,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
-name = "drm-fourcc"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebbf3a5ed4671aabffefce172ff43d69c1f27dd2c6aea28e5212a70f32ada0cf"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,16 +852,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da96828553a086d7b18dcebfc579bd9628b016f86590d7453c115e490fa74b80"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "external-memory"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4dfe8d292b014422776a8c516862d2bff8a81b223a4461dfdc45f3862dc9d39"
-dependencies = [
- "bitflags",
- "drm-fourcc",
 ]
 
 [[package]]
@@ -913,9 +894,9 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+checksum = "398ea4fabe40b9b0d885340a2a991a44c8a645624075ad966d21f88688e2b69e"
 
 [[package]]
 name = "fluidlite"
@@ -1098,168 +1079,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gfx-auxil"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1694991b11d642680e82075a75c7c2bd75556b805efa7660b705689f05b1ab1c"
-dependencies = [
- "fxhash",
- "gfx-hal",
- "spirv_cross",
-]
-
-[[package]]
-name = "gfx-backend-dx11"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9e453baf3aaef2b0c354ce0b3d63d76402e406a59b64b7182d123cfa6635ae"
-dependencies = [
- "arrayvec",
- "bitflags",
- "gfx-auxil",
- "gfx-hal",
- "gfx-renderdoc",
- "libloading 0.7.0",
- "log",
- "parking_lot",
- "range-alloc",
- "raw-window-handle",
- "smallvec",
- "spirv_cross",
- "thunderdome",
- "winapi",
- "wio",
-]
-
-[[package]]
-name = "gfx-backend-dx12"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21506399f64a3c4d389182a89a30073856ae33eb712315456b4fd8f39ee7682a"
-dependencies = [
- "arrayvec",
- "bit-set",
- "bitflags",
- "d3d12",
- "gfx-auxil",
- "gfx-hal",
- "gfx-renderdoc",
- "log",
- "parking_lot",
- "range-alloc",
- "raw-window-handle",
- "smallvec",
- "spirv_cross",
- "thunderdome",
- "winapi",
-]
-
-[[package]]
-name = "gfx-backend-empty"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c8f813c47791918aa00dc9c9ddf961d23fa8c2a5d869e6cb8ea84f944820f4"
-dependencies = [
- "gfx-hal",
- "log",
- "raw-window-handle",
-]
-
-[[package]]
-name = "gfx-backend-gl"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bae057fc3a0ab23ecf97ae51d4017d27d5ddf0aab16ee6dcb58981af88c3152"
-dependencies = [
- "arrayvec",
- "bitflags",
- "fxhash",
- "gfx-hal",
- "glow",
- "js-sys",
- "khronos-egl",
- "libloading 0.7.0",
- "log",
- "naga",
- "parking_lot",
- "raw-window-handle",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "gfx-backend-metal"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de85808e2a98994c6af925253f8a9593bc57180ef1ea137deab6d35cc949517"
-dependencies = [
- "arrayvec",
- "bitflags",
- "block",
- "cocoa-foundation",
- "copyless",
- "core-graphics-types",
- "foreign-types",
- "fxhash",
- "gfx-hal",
- "log",
- "metal",
- "naga",
- "objc",
- "parking_lot",
- "profiling",
- "range-alloc",
- "raw-window-handle",
- "storage-map",
-]
-
-[[package]]
-name = "gfx-backend-vulkan"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9861ec855acbbc65c0e4f966d761224886e811dc2c6d413a4776e9293d0e5c0"
-dependencies = [
- "arrayvec",
- "ash",
- "byteorder",
- "core-graphics-types",
- "gfx-hal",
- "gfx-renderdoc",
- "inplace_it",
- "log",
- "naga",
- "objc",
- "parking_lot",
- "raw-window-handle",
- "smallvec",
- "winapi",
-]
-
-[[package]]
-name = "gfx-hal"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbb575ea793dd0507b3082f4f2cde62dc9f3cebd98f5cd49ba2a4da97a976fd"
-dependencies = [
- "bitflags",
- "external-memory",
- "naga",
- "raw-window-handle",
- "thiserror",
-]
-
-[[package]]
-name = "gfx-renderdoc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8027995e247e2426d3a00d13f5191dd56c314bff02dc4b54cbf727f1ba9c40a"
-dependencies = [
- "libloading 0.7.0",
- "log",
- "renderdoc-sys",
-]
-
-[[package]]
 name = "glam"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1276,9 +1095,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "glow"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b80b98efaa8a34fce11d60dd2ce2760d5d83c373cbcc73bb87c2a3a84a54108"
+checksum = "4f04649123493bc2483cbef4daddb45d40bbdae5adb221a63a23efdb0cc99520"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -1327,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "gpu-alloc"
-version = "0.4.7"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc1b6ca374e81862526786d9cb42357ce03706ed1b8761730caafd02ab91f3a"
+checksum = "0e64cbb8d36508d3e19da95e56e196a84f674fc190881f2cc010000798838aa6"
 dependencies = [
  "bitflags",
  "gpu-alloc-types",
@@ -1346,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "gpu-descriptor"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a70f1e87a3840ed6a3e99e02c2b861e4dbdf26f0d07e38f42ea5aff46cfce2"
+checksum = "d7a237f0419ab10d17006d55c62ac4f689a6bf52c75d3f38b8361d249e8d4b0b"
 dependencies = [
  "bitflags",
  "gpu-descriptor-types",
@@ -1407,7 +1226,7 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 [[package]]
 name = "iced_core"
 version = "0.4.0"
-source = "git+https://github.com/hecrj/iced.git?rev=cdd2f247f8c22775a5035be03715775c96cd1037#cdd2f247f8c22775a5035be03715775c96cd1037"
+source = "git+https://github.com/hecrj/iced.git?rev=73f288156899ddd51ae686e95bdf09f9bd129df4#73f288156899ddd51ae686e95bdf09f9bd129df4"
 dependencies = [
  "bitflags",
 ]
@@ -1415,7 +1234,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.3.0"
-source = "git+https://github.com/hecrj/iced.git?rev=cdd2f247f8c22775a5035be03715775c96cd1037#cdd2f247f8c22775a5035be03715775c96cd1037"
+source = "git+https://github.com/hecrj/iced.git?rev=73f288156899ddd51ae686e95bdf09f9bd129df4#73f288156899ddd51ae686e95bdf09f9bd129df4"
 dependencies = [
  "futures",
  "log",
@@ -1425,7 +1244,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.2.0"
-source = "git+https://github.com/hecrj/iced.git?rev=cdd2f247f8c22775a5035be03715775c96cd1037#cdd2f247f8c22775a5035be03715775c96cd1037"
+source = "git+https://github.com/hecrj/iced.git?rev=73f288156899ddd51ae686e95bdf09f9bd129df4#73f288156899ddd51ae686e95bdf09f9bd129df4"
 dependencies = [
  "bytemuck",
  "glam",
@@ -1438,7 +1257,7 @@ dependencies = [
 [[package]]
 name = "iced_native"
 version = "0.4.0"
-source = "git+https://github.com/hecrj/iced.git?rev=cdd2f247f8c22775a5035be03715775c96cd1037#cdd2f247f8c22775a5035be03715775c96cd1037"
+source = "git+https://github.com/hecrj/iced.git?rev=73f288156899ddd51ae686e95bdf09f9bd129df4#73f288156899ddd51ae686e95bdf09f9bd129df4"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -1450,7 +1269,7 @@ dependencies = [
 [[package]]
 name = "iced_style"
 version = "0.3.0"
-source = "git+https://github.com/hecrj/iced.git?rev=cdd2f247f8c22775a5035be03715775c96cd1037#cdd2f247f8c22775a5035be03715775c96cd1037"
+source = "git+https://github.com/hecrj/iced.git?rev=73f288156899ddd51ae686e95bdf09f9bd129df4#73f288156899ddd51ae686e95bdf09f9bd129df4"
 dependencies = [
  "iced_core",
 ]
@@ -1458,7 +1277,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.4.0"
-source = "git+https://github.com/hecrj/iced.git?rev=cdd2f247f8c22775a5035be03715775c96cd1037#cdd2f247f8c22775a5035be03715775c96cd1037"
+source = "git+https://github.com/hecrj/iced.git?rev=73f288156899ddd51ae686e95bdf09f9bd129df4#73f288156899ddd51ae686e95bdf09f9bd129df4"
 dependencies = [
  "bytemuck",
  "futures",
@@ -1752,9 +1571,9 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79d7d769f1c104b8388294d6594d491d2e21240636f5f94d37f8a0f3d7904450"
+checksum = "e0514f491f4cc03632ab399ee01e2c1c1b12d3e1cf2d667c1ff5f87d6dcd2084"
 dependencies = [
  "bitflags",
  "block",
@@ -1853,9 +1672,9 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.5.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef670817eef03d356d5a509ea275e7dd3a78ea9e24261ea3cb2dfed1abb08f64"
+checksum = "8c5859e55c51da10b98e7a73068e0a0c5da7bbcae4fc38f86043d0c6d1b917cf"
 dependencies = [
  "bit-set",
  "bitflags",
@@ -1864,8 +1683,7 @@ dependencies = [
  "log",
  "num-traits",
  "petgraph",
- "rose_tree",
- "spirv_headers",
+ "spirv",
  "thiserror",
 ]
 
@@ -2272,9 +2090,9 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "petgraph"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -2541,15 +2359,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rose_tree"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284de9dae38774e2813aaabd7e947b4a6fe9b8c58c2309f754a487cdd50de1c2"
-dependencies = [
- "petgraph",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2696,9 +2505,12 @@ checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
 
 [[package]]
 name = "slotmap"
-version = "0.4.2"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61b40583e0c1bd3100652ba8940939decc8808e7b2a07f4f4606c6a8a40035a"
+checksum = "e1e08e261d0e8f5c43123b7adf3e4ca1690d655377ac93a03b2c9d3e98de1342"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -2740,21 +2552,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "spirv_cross"
-version = "0.23.1"
+name = "spirv"
+version = "0.2.0+1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60647fadbf83c4a72f0d7ea67a7ca3a81835cf442b8deae5c134c3e0055b2e14"
-dependencies = [
- "cc",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "spirv_headers"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f5b132530b1ac069df335577e3581765995cba5a13995cdbbdbc8fb057c532c"
+checksum = "246bfa38fe3db3f1dfc8ca5a2cdeb7348c78be2112740cc0ec8ef18b6d94f830"
 dependencies = [
  "bitflags",
  "num-traits",
@@ -2829,15 +2630,6 @@ name = "stdweb-internal-runtime"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
-
-[[package]]
-name = "storage-map"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418bb14643aa55a7841d5303f72cf512cfb323b8cc221d51580500a1ca75206c"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "strsim"
@@ -2916,12 +2708,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "thunderdome"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b4947742c93ece24a0032141d9caa3d853752e694a57e35029dd2bd08673e0"
 
 [[package]]
 name = "time"
@@ -3273,9 +3059,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.50"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3302,14 +3088,13 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "0.9.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd247f8b26fd3d42ef2f320d378025cd6e84d782ef749fab45cc3b981fbe3275"
+checksum = "cb12c02c9b6fb0db46fcc14b0c16bd2d9351331c98c04bd19f32df281c504047"
 dependencies = [
  "arrayvec",
  "js-sys",
  "log",
- "naga",
  "parking_lot",
  "raw-window-handle",
  "smallvec",
@@ -3317,29 +3102,21 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "wgpu-core",
+ "wgpu-hal",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-core"
-version = "0.9.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958a8a5e418492723ab4e7933bf6dbdf06f5dc87274ba2ae0e4f9c891aac579c"
+checksum = "f963c62473a36e3cef6c58181f2ed6d0d38d2043d970dbed46cb197190090c99"
 dependencies = [
  "arrayvec",
  "bitflags",
  "cfg_aliases",
  "copyless",
  "fxhash",
- "gfx-backend-dx11",
- "gfx-backend-dx12",
- "gfx-backend-empty",
- "gfx-backend-gl",
- "gfx-backend-metal",
- "gfx-backend-vulkan",
- "gfx-hal",
- "gpu-alloc",
- "gpu-descriptor",
  "log",
  "naga",
  "parking_lot",
@@ -3347,23 +3124,58 @@ dependencies = [
  "raw-window-handle",
  "smallvec",
  "thiserror",
+ "wgpu-hal",
  "wgpu-types",
 ]
 
 [[package]]
-name = "wgpu-types"
-version = "0.9.0"
+name = "wgpu-hal"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5c9678cd533558e28b416d66947b099742df1939307478db54f867137f1b60"
+checksum = "27cd894b17bff1958ee93da1cc991fd64bf99667746d4bd2a7403855f4d37fe2"
+dependencies = [
+ "arrayvec",
+ "ash",
+ "bit-set",
+ "bitflags",
+ "block",
+ "core-graphics-types",
+ "d3d12",
+ "foreign-types",
+ "fxhash",
+ "glow",
+ "gpu-alloc",
+ "gpu-descriptor",
+ "inplace_it",
+ "khronos-egl",
+ "libloading 0.7.0",
+ "log",
+ "metal",
+ "naga",
+ "objc",
+ "parking_lot",
+ "range-alloc",
+ "raw-window-handle",
+ "renderdoc-sys",
+ "thiserror",
+ "wgpu-types",
+ "winapi",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25feb2fbf24ab3219a9f10890ceb8e1ef02b13314ed89d64a9ae99dcad883e18"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "wgpu_glyph"
-version = "0.13.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fee8c96eda18195a7ad9989737183e0a357f14b15e98838c76abbcf56a5f970"
+checksum = "cbf11aebbcf20806535bee127367bcb393c83d77c60c4f7917184d839716cf41"
 dependencies = [
  "bytemuck",
  "glyph_brush",
@@ -3441,15 +3253,6 @@ dependencies = [
  "web-sys",
  "winapi",
  "x11-dl",
-]
-
-[[package]]
-name = "wio"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
-dependencies = [
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.8"
 authors = ["Poly <marynczak.bartlomiej@gmail.com>"]
 edition = "2018"
 default-run = "neothesia"
+resolver = "2"
 
 [features]
 default = [ "app" ]
@@ -24,8 +25,8 @@ futures = "0.3.12"
 # winit = "0.24.0"
 winit = { git = "https://github.com/PolyMeilex/winit.git" } 
 
-wgpu = "0.9.0"
-wgpu_glyph = "0.13.0"
+wgpu = "0.10"
+wgpu_glyph = "0.14"
 
 
 log = "0.4.14"
@@ -36,9 +37,9 @@ nfd2 = { version="0.3.0", optional = true }
 lib_midi = {path="./lib_midi"}
 midir = "0.7.0"
 
-iced_native = { git="https://github.com/hecrj/iced.git", rev="cdd2f247f8c22775a5035be03715775c96cd1037", optional = true }
-iced_wgpu = { git="https://github.com/hecrj/iced.git", rev="cdd2f247f8c22775a5035be03715775c96cd1037", features = ["png"], optional = true} 
-iced_graphics = { git="https://github.com/hecrj/iced.git", rev="cdd2f247f8c22775a5035be03715775c96cd1037", optional = true} 
+iced_native = { git="https://github.com/hecrj/iced.git", rev="73f288156899ddd51ae686e95bdf09f9bd129df4", optional = true }
+iced_wgpu = { git="https://github.com/hecrj/iced.git", rev="73f288156899ddd51ae686e95bdf09f9bd129df4", features = ["png"], optional = true} 
+iced_graphics = { git="https://github.com/hecrj/iced.git", rev="73f288156899ddd51ae686e95bdf09f9bd129df4", optional = true} 
 
 cpal = { version = "0.13.1", optional = true }
 fluidlite = {git= "https://github.com/PolyMeilex/fluidlite-rs.git", optional = true}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use neothesia::{
     utils::timer::Fps,
 };
 
+use wgpu::TextureViewDescriptor;
 use winit::{event::WindowEvent, event_loop::ControlFlow};
 
 pub struct Neothesia {
@@ -140,18 +141,19 @@ impl Neothesia {
                 Err(err) => log::warn!("{:?}", err),
             }
         };
+        let texture_descriptor = TextureViewDescriptor::default();
 
         self.target.gpu.clear(
-            &frame.output.view,
+            &frame.output.texture.create_view(&texture_descriptor),
             self.target.state.config.background_color.into(),
         );
 
-        self.game_scene.render(&mut self.target, &frame.output.view);
+        self.game_scene.render(&mut self.target, &frame.output.texture.create_view(&texture_descriptor));
 
         self.target.text_renderer.render(
             &self.target.window,
             &mut self.target.gpu,
-            &frame.output.view,
+            &frame.output.texture.create_view(&texture_descriptor),
         );
 
         self.target.gpu.submit().unwrap();

--- a/src/quad_pipeline/instance_data.rs
+++ b/src/quad_pipeline/instance_data.rs
@@ -30,7 +30,7 @@ impl QuadInstance {
     pub fn layout(attributes: &[wgpu::VertexAttribute]) -> wgpu::VertexBufferLayout {
         wgpu::VertexBufferLayout {
             array_stride: std::mem::size_of::<QuadInstance>() as wgpu::BufferAddress,
-            step_mode: wgpu::InputStepMode::Instance,
+            step_mode: wgpu::VertexStepMode::Instance,
             attributes,
         }
     }

--- a/src/quad_pipeline/mod.rs
+++ b/src/quad_pipeline/mod.rs
@@ -20,8 +20,7 @@ impl<'a> QuadPipeline {
                 label: Some("RectanglePipeline::shader"),
                 source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(include_str!(
                     "./shader/quad.wgsl"
-                ))),
-                flags: wgpu::ShaderFlags::all(),
+                )))
             });
 
         let render_pipeline_layout =

--- a/src/scene/menu_scene/bg_pipeline/mod.rs
+++ b/src/scene/menu_scene/bg_pipeline/mod.rs
@@ -18,14 +18,13 @@ impl<'a> BgPipeline {
                 label: Some("RectanglePipeline::shader"),
                 source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(include_str!(
                     "./shader/bg.wgsl"
-                ))),
-                flags: wgpu::ShaderFlags::all(),
+                )))
             });
 
         let time_uniform = Uniform::new(
             &gpu.device,
             TimeUniform::default(),
-            wgpu::ShaderStage::FRAGMENT,
+            wgpu::ShaderStages::FRAGMENT,
         );
 
         let render_pipeline_layout =

--- a/src/scene/playing_scene/notes_pipeline/instance_data.rs
+++ b/src/scene/playing_scene/notes_pipeline/instance_data.rs
@@ -17,7 +17,7 @@ impl NoteInstance {
     pub fn layout(attributes: &[wgpu::VertexAttribute]) -> wgpu::VertexBufferLayout {
         wgpu::VertexBufferLayout {
             array_stride: std::mem::size_of::<NoteInstance>() as wgpu::BufferAddress,
-            step_mode: wgpu::InputStepMode::Instance,
+            step_mode: wgpu::VertexStepMode::Instance,
             attributes,
         }
     }

--- a/src/scene/playing_scene/notes_pipeline/mod.rs
+++ b/src/scene/playing_scene/notes_pipeline/mod.rs
@@ -25,14 +25,13 @@ impl<'a> NotesPipeline {
                 label: Some("RectanglePipeline::shader"),
                 source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(include_str!(
                     "./shader/note.wgsl"
-                ))),
-                flags: wgpu::ShaderFlags::all(),
+                )))
             });
 
         let time_uniform = Uniform::new(
             &target.gpu.device,
             TimeUniform::default(),
-            wgpu::ShaderStage::VERTEX,
+            wgpu::ShaderStages::VERTEX,
         );
 
         let render_pipeline_layout =

--- a/src/target.rs
+++ b/src/target.rs
@@ -24,7 +24,7 @@ impl Target {
         let transform_uniform = Uniform::new(
             &gpu.device,
             TransformUniform::default(),
-            wgpu::ShaderStage::VERTEX | wgpu::ShaderStage::FRAGMENT,
+            wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
         );
 
         let text_renderer = TextRenderer::new(&gpu);

--- a/src/ui/iced_manager.rs
+++ b/src/ui/iced_manager.rs
@@ -10,12 +10,13 @@ impl IcedManager {
     pub fn new(device: &wgpu::Device, window: &Window) -> Self {
         let debug = iced_native::Debug::new();
 
-        let settings = iced_wgpu::Settings {
-            format: wgpu_jumpstart::TEXTURE_FORMAT,
-            ..Default::default()
-        };
+        let settings = iced_wgpu::Settings::default();
 
-        let renderer = iced_wgpu::Renderer::new(iced_wgpu::Backend::new(device, settings));
+        let renderer = iced_wgpu::Renderer::new(iced_wgpu::Backend::new(
+            device,
+            settings,
+            wgpu_jumpstart::TEXTURE_FORMAT,
+        ));
 
         let physical_size = window.state.physical_size;
         let viewport = iced_wgpu::Viewport::with_physical_size(

--- a/src/wgpu_jumpstart/gpu.rs
+++ b/src/wgpu_jumpstart/gpu.rs
@@ -16,16 +16,16 @@ impl Gpu {
     ) -> Result<(Self, wgpu::Surface), GpuInitError> {
         let backend = if let Ok(backend) = std::env::var("WGPU_BACKEND") {
             match backend.to_lowercase().as_str() {
-                "vulkan" => wgpu::BackendBit::VULKAN,
-                "metal" => wgpu::BackendBit::METAL,
-                "dx12" => wgpu::BackendBit::DX12,
-                "dx11" => wgpu::BackendBit::DX11,
-                "gl" => wgpu::BackendBit::GL,
-                "webgpu" => wgpu::BackendBit::BROWSER_WEBGPU,
+                "vulkan" => wgpu::Backends::VULKAN,
+                "metal" => wgpu::Backends::METAL,
+                "dx12" => wgpu::Backends::DX12,
+                "dx11" => wgpu::Backends::DX11,
+                "gl" => wgpu::Backends::GL,
+                "webgpu" => wgpu::Backends::BROWSER_WEBGPU,
                 other => panic!("Unknown backend: {}", other),
             }
         } else {
-            wgpu::BackendBit::PRIMARY
+            wgpu::Backends::PRIMARY
         };
 
         let instance = wgpu::Instance::new(backend);
@@ -41,7 +41,7 @@ impl Gpu {
             .ok_or(GpuInitError::AdapterRequest)?;
 
         let adapter_info = adapter.get_info();
-        let format = adapter.get_swap_chain_preferred_format(&surface);
+        let format = surface.get_preferred_format(&adapter);
 
         log::info!(
             "Using {} ({:?}, Preferred Format: {:?})",

--- a/src/wgpu_jumpstart/instances.rs
+++ b/src/wgpu_jumpstart/instances.rs
@@ -18,7 +18,7 @@ where
         let buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: None,
             size: (instance_size * max_size) as u64,
-            usage: wgpu::BufferUsage::VERTEX | wgpu::BufferUsage::COPY_DST,
+            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
 
@@ -37,7 +37,7 @@ where
         let staging_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: None,
             contents: bytemuck::cast_slice(&self.data),
-            usage: wgpu::BufferUsage::COPY_SRC,
+            usage: wgpu::BufferUsages::COPY_SRC,
         });
 
         command_encoder.copy_buffer_to_buffer(&staging_buffer, 0, &self.buffer, 0, buffer_size);

--- a/src/wgpu_jumpstart/render_pipeline_builder.rs
+++ b/src/wgpu_jumpstart/render_pipeline_builder.rs
@@ -51,7 +51,7 @@ impl<'a> RenderPipelineBuilder<'a> {
                         operation: wgpu::BlendOperation::Add,
                     },
                 }),
-                write_mask: wgpu::ColorWrite::ALL,
+                write_mask: wgpu::ColorWrites::ALL,
             }],
         });
         self

--- a/src/wgpu_jumpstart/shape.rs
+++ b/src/wgpu_jumpstart/shape.rs
@@ -12,12 +12,12 @@ impl Shape {
         let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: None,
             contents: bytemuck::cast_slice(&vertices),
-            usage: wgpu::BufferUsage::VERTEX,
+            usage: wgpu::BufferUsages::VERTEX,
         });
         let index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: None,
             contents: bytemuck::cast_slice(&indices),
-            usage: wgpu::BufferUsage::INDEX,
+            usage: wgpu::BufferUsages::INDEX,
         });
         Self {
             vertex_buffer,
@@ -116,7 +116,7 @@ impl Vertex2D {
         use std::mem;
         wgpu::VertexBufferLayout {
             array_stride: mem::size_of::<Vertex2D>() as wgpu::BufferAddress,
-            step_mode: wgpu::InputStepMode::Vertex,
+            step_mode: wgpu::VertexStepMode::Vertex,
             attributes: &[wgpu::VertexAttribute {
                 offset: 0,
                 shader_location: 0,

--- a/src/wgpu_jumpstart/uniform.rs
+++ b/src/wgpu_jumpstart/uniform.rs
@@ -15,7 +15,7 @@ impl<U> Uniform<U>
 where
     U: Pod,
 {
-    pub fn new(device: &wgpu::Device, data: U, visibility: wgpu::ShaderStage) -> Self {
+    pub fn new(device: &wgpu::Device, data: U, visibility: wgpu::ShaderStages) -> Self {
         let bind_group_layout_descriptor = wgpu::BindGroupLayoutDescriptor {
             label: None,
             entries: &[wgpu::BindGroupLayoutEntry {
@@ -33,7 +33,7 @@ where
         let buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: None,
             contents: bytemuck::cast_slice(&[data]),
-            usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
 
         let bind_group_layout = device.create_bind_group_layout(&bind_group_layout_descriptor);
@@ -62,7 +62,7 @@ where
         let staging_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: None,
             contents: bytemuck::cast_slice(&[self.data]),
-            usage: wgpu::BufferUsage::COPY_SRC,
+            usage: wgpu::BufferUsages::COPY_SRC,
         });
 
         command_encoder.copy_buffer_to_buffer(


### PR DESCRIPTION
Update `wgpu` to 0.10 and adapt the code to the API changes.

`iced` is also updated since it uses `wgpu` as well, this change also requires setting the Cargo `resolver` to be version 2 (Rust 1.51+).