### PR TITLE
fix building ffmpeg on archlinux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1792,6 +1792,7 @@ dependencies = [
  "bytemuck",
  "cpal",
  "env_logger 0.9.0",
+ "ffmpeg-sys",
  "fluidlite",
  "fps_ticker",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ serde = { version = "1.0.123", features = ["serde_derive"] }
 mpeg_encoder = { git = "https://github.com/PolyMeilex/mpeg_encoder_next.git", optional = true }
 midi = "0.1.0"
 num = "0.4.0"
+ffmpeg-sys = { version = "4.3.3", features = ["build"] }
 # mpeg_encoder = {path="../mpeg_encoder_next", optional=true}
 
 [target.'cfg(target_os = "macos")'.dependencies]


### PR DESCRIPTION
Works on the ffmpeg shipped with arch, im not sure if that change can be
bad for other distros.

Fixes #27
