### PR TITLE
Fix note off implementation for oxisynth

### DIFF
--- a/neothesia/src/output_manager/synth_backend.rs
+++ b/neothesia/src/output_manager/synth_backend.rs
@@ -187,7 +187,14 @@ impl OutputConnection for SynthOutputConnection {
     }
 
     fn stop_all(&mut self) {
-        self.tx.send(oxisynth::MidiEvent::SystemReset).ok();
+        for channel in 0..16 {
+            self.tx
+                .send(oxisynth::MidiEvent::AllNotesOff { channel })
+                .ok();
+            self.tx
+                .send(oxisynth::MidiEvent::AllSoundOff { channel })
+                .ok();
+        }
     }
 }
 


### PR DESCRIPTION
System reset result in midi programs being messed up, so let's just send note/sound off events