### PR TITLE
Improve timestamp calculations perf 8x

### DIFF
--- a/midi-file/src/track.rs
+++ b/midi-file/src/track.rs
@@ -21,6 +21,7 @@ pub struct MidiEvent {
 pub struct TempoEvent {
     pub absolute_pulses: u64,
     pub relative_pulses: u64,
+    pub timestamp: Duration,
     /// Tempo in microseconds per quarter note.
     pub tempo: u32,
 }


### PR DESCRIPTION
On a test black midi files this improves load time about 8 times.
Worst case found improved from 7.7min load time to just 55s.