### PR TITLE
Add `install-app` makefile recipe

### DIFF
--- a/makefile
+++ b/makefile
@@ -3,9 +3,13 @@ build-app:
 run-app:
 	cargo run --release --bin neothesia
 
+install-app:
+	cargo install --path neothesia
+
 check-recorder:
 	cargo check -p neothesia-cli
 build-recorder:
 	cargo build --release -p neothesia-cli
 run-recorder:
 	cargo run --release -p neothesia-cli -- $(file)
+


### PR DESCRIPTION
Add makefile recipe to install to `.cargo/bin` directory.
Same as `build-app`, but binary can be included in `$PATH`.