### PR TITLE
[CI] MACOSX_DEPLOYMENT_TARGET: 10.12

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,6 +2,9 @@ name: Rust
 
 on: [push, pull_request]
 
+env:
+  MACOSX_DEPLOYMENT_TARGET: 10.12
+
 jobs:
   build_ubuntu:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This fixes this cryptic error message `LSOpenURLsWithRole() failed with error -10825 for the file`

Our min version was set to 12.0 by default:
`llvm-otool -l ./neothesia`
```
cmd LC_BUILD_VERSION
cmdsize 32
platform 1
sdk 13.1
minos 12.0
```
After this change, we get lower requirements back to 10.12:
```
cmd LC_VERSION_MIN_MACOSX
cmdsize 16
version 10.12
```
