### PR TITLE
Rename Target to Context

### DIFF
--- a/neothesia/src/context.rs
+++ b/neothesia/src/context.rs
@@ -12,7 +12,7 @@ use winit::event_loop::EventLoopProxy;
 use crate::iced_utils::IcedManager;
 use winit::window::Window;
 
-pub struct Target {
+pub struct Context {
     pub window: Arc<Window>,
     pub iced_manager: IcedManager,
 
@@ -31,7 +31,7 @@ pub struct Target {
     pub proxy: EventLoopProxy<NeothesiaEvent>,
 }
 
-impl Target {
+impl Context {
     pub fn new(
         window: Arc<Window>,
         window_state: WindowState,

--- a/neothesia/src/scene/menu_scene/iced_menu/exit.rs
+++ b/neothesia/src/scene/menu_scene/iced_menu/exit.rs
@@ -3,18 +3,18 @@ use iced_runtime::Command;
 use iced_widget::{column as col, row};
 
 use crate::{
-    iced_utils::iced_state::Element, scene::menu_scene::neo_btn::neo_button, target::Target,
+    context::Context, iced_utils::iced_state::Element, scene::menu_scene::neo_btn::neo_button,
     NeothesiaEvent,
 };
 
 use super::{center_x, centered_text, Data, Message, Step};
 
-pub(super) fn update(_data: &mut Data, _msg: (), target: &mut Target) -> Command<Message> {
-    target.proxy.send_event(NeothesiaEvent::Exit).ok();
+pub(super) fn update(_data: &mut Data, _msg: (), ctx: &mut Context) -> Command<Message> {
+    ctx.proxy.send_event(NeothesiaEvent::Exit).ok();
     Command::none()
 }
 
-pub(super) fn view<'a>(_data: &'a Data, _target: &Target) -> Element<'a, Message> {
+pub(super) fn view<'a>(_data: &'a Data, _ctx: &Context) -> Element<'a, Message> {
     let output = centered_text("Do you want to exit?").size(30);
 
     let select_row = row![

--- a/neothesia/src/scene/menu_scene/iced_menu/midi_file_picker.rs
+++ b/neothesia/src/scene/menu_scene/iced_menu/midi_file_picker.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use iced_runtime::Command;
 
-use crate::{song::Song, target::Target};
+use crate::{context::Context, song::Song};
 
 use super::{Data, Message};
 
@@ -21,7 +21,7 @@ impl From<MidiFilePickerMessage> for Message {
 pub(super) fn update(
     data: &mut Data,
     msg: MidiFilePickerMessage,
-    target: &mut Target,
+    ctx: &mut Context,
 ) -> Command<Message> {
     match msg {
         MidiFilePickerMessage::OpenMidiFilePicker => {
@@ -30,8 +30,8 @@ pub(super) fn update(
         }
         MidiFilePickerMessage::MidiFileLoaded(midi) => {
             if let Some((midi, path)) = midi {
-                target.config.last_opened_song = Some(path);
-                target.song = Some(Song::new(midi));
+                ctx.config.last_opened_song = Some(path);
+                ctx.song = Some(Song::new(midi));
             }
             data.is_loading = false;
         }

--- a/neothesia/src/scene/menu_scene/iced_menu/tracks.rs
+++ b/neothesia/src/scene/menu_scene/iced_menu/tracks.rs
@@ -6,6 +6,7 @@ use iced_runtime::Command;
 use iced_widget::{button, column as col, container, row, vertical_space};
 
 use crate::{
+    context::Context,
     iced_utils::iced_state::Element,
     scene::menu_scene::{
         icons,
@@ -14,7 +15,6 @@ use crate::{
         segment_button, track_card,
     },
     song::PlayerConfig,
-    target::Target,
 };
 
 use super::{centered_text, theme, Data, Message};
@@ -32,26 +32,22 @@ impl From<TracksMessage> for Message {
     }
 }
 
-pub(super) fn update(
-    _data: &mut Data,
-    msg: TracksMessage,
-    target: &mut Target,
-) -> Command<Message> {
+pub(super) fn update(_data: &mut Data, msg: TracksMessage, ctx: &mut Context) -> Command<Message> {
     match msg {
         TracksMessage::AllTracksPlayer(config) => {
-            if let Some(song) = target.song.as_mut() {
+            if let Some(song) = ctx.song.as_mut() {
                 for track in song.config.tracks.iter_mut() {
                     track.player = config.clone();
                 }
             }
         }
         TracksMessage::TrackPlayer(track, config) => {
-            if let Some(song) = target.song.as_mut() {
+            if let Some(song) = ctx.song.as_mut() {
                 song.config.tracks[track].player = config;
             }
         }
         TracksMessage::TrackVisibility(track, visible) => {
-            if let Some(song) = target.song.as_mut() {
+            if let Some(song) = ctx.song.as_mut() {
                 song.config.tracks[track].visible = visible;
             }
         }
@@ -60,9 +56,9 @@ pub(super) fn update(
     Command::none()
 }
 
-pub(super) fn view<'a>(_data: &'a Data, target: &Target) -> Element<'a, Message> {
+pub(super) fn view<'a>(_data: &'a Data, ctx: &Context) -> Element<'a, Message> {
     let mut tracks = Vec::new();
-    if let Some(song) = target.song.as_ref() {
+    if let Some(song) = ctx.song.as_ref() {
         for track in song.file.tracks.iter().filter(|t| !t.notes.is_empty()) {
             let config = &song.config.tracks[track.track_id];
 
@@ -77,8 +73,8 @@ pub(super) fn view<'a>(_data: &'a Data, target: &Target) -> Element<'a, Message>
             let color = if !visible {
                 iced_core::Color::from_rgb8(102, 102, 102)
             } else {
-                let color_id = track.track_color_id % target.config.color_schema.len();
-                let color = &target.config.color_schema[color_id].base;
+                let color_id = track.track_color_id % ctx.config.color_schema.len();
+                let color = &ctx.config.color_schema[color_id].base;
                 iced_core::Color::from_rgb8(color.0, color.1, color.2)
             };
 
@@ -149,7 +145,7 @@ pub(super) fn view<'a>(_data: &'a Data, target: &Target) -> Element<'a, Message>
         .min_width(80.0)
         .on_press(Message::Play);
 
-        if target.song.is_some() {
+        if ctx.song.is_some() {
             row![play]
         } else {
             row![]

--- a/neothesia/src/scene/mod.rs
+++ b/neothesia/src/scene/mod.rs
@@ -1,20 +1,20 @@
 pub mod menu_scene;
 pub mod playing_scene;
 
-use crate::target::Target;
+use crate::context::Context;
 use midi_file::midly::MidiMessage;
 use std::time::Duration;
 use wgpu_jumpstart::{TransformUniform, Uniform};
 use winit::event::WindowEvent;
 
 pub trait Scene {
-    fn resize(&mut self, _target: &mut Target) {}
-    fn update(&mut self, target: &mut Target, delta: Duration);
+    fn resize(&mut self, _ctx: &mut Context) {}
+    fn update(&mut self, ctx: &mut Context, delta: Duration);
     fn render<'pass>(
         &'pass mut self,
         transform: &'pass Uniform<TransformUniform>,
         rpass: &mut wgpu::RenderPass<'pass>,
     );
-    fn window_event(&mut self, _target: &mut Target, _event: &WindowEvent) {}
-    fn midi_event(&mut self, _target: &mut Target, _channel: u8, _message: &MidiMessage) {}
+    fn window_event(&mut self, _ctx: &mut Context, _event: &WindowEvent) {}
+    fn midi_event(&mut self, _ctx: &mut Context, _channel: u8, _message: &MidiMessage) {}
 }

--- a/neothesia/src/scene/playing_scene/keyboard.rs
+++ b/neothesia/src/scene/playing_scene/keyboard.rs
@@ -5,7 +5,7 @@ use neothesia_core::{
 };
 use piano_math::KeyboardRange;
 
-use crate::{config::Config, render::KeyboardRenderer, song::SongConfig, target::Target};
+use crate::{config::Config, context::Context, render::KeyboardRenderer, song::SongConfig};
 
 pub struct Keyboard {
     renderer: KeyboardRenderer,
@@ -25,15 +25,15 @@ fn get_layout(
 }
 
 impl Keyboard {
-    pub fn new(target: &Target, song_config: SongConfig) -> Self {
+    pub fn new(ctx: &Context, song_config: SongConfig) -> Self {
         let layout = get_layout(
-            target.window_state.logical_size.width,
-            target.window_state.logical_size.height,
-            piano_math::KeyboardRange::new(target.config.piano_range()),
+            ctx.window_state.logical_size.width,
+            ctx.window_state.logical_size.height,
+            piano_math::KeyboardRange::new(ctx.config.piano_range()),
         );
 
         let mut renderer = KeyboardRenderer::new(layout);
-        renderer.position_on_bottom_of_parent(target.window_state.logical_size.height);
+        renderer.position_on_bottom_of_parent(ctx.window_state.logical_size.height);
 
         Self {
             renderer,
@@ -61,15 +61,15 @@ impl Keyboard {
         self.renderer.position_on_bottom_of_parent(parent_height)
     }
 
-    pub fn resize(&mut self, target: &Target) {
+    pub fn resize(&mut self, ctx: &Context) {
         let keyboard_layout = get_layout(
-            target.window_state.logical_size.width,
-            target.window_state.logical_size.height,
+            ctx.window_state.logical_size.width,
+            ctx.window_state.logical_size.height,
             self.renderer.layout().range.clone(),
         );
 
         self.set_layout(keyboard_layout.clone());
-        self.position_on_bottom_of_parent(target.window_state.logical_size.height);
+        self.position_on_bottom_of_parent(ctx.window_state.logical_size.height);
     }
 
     pub fn update(&mut self, quads: &mut QuadPipeline, brush: &mut TextRenderer) {

--- a/neothesia/src/scene/playing_scene/rewind_controller.rs
+++ b/neothesia/src/scene/playing_scene/rewind_controller.rs
@@ -4,7 +4,7 @@ use winit::{
 };
 
 use super::MidiPlayer;
-use crate::{target::Target, utils::window::WindowState};
+use crate::{context::Context, utils::window::WindowState};
 
 pub enum RewindController {
     Keyboard { speed: i64, was_paused: bool },
@@ -50,11 +50,11 @@ impl RewindController {
         }
     }
 
-    pub fn update(&self, player: &mut MidiPlayer, target: &Target) {
+    pub fn update(&self, player: &mut MidiPlayer, ctx: &Context) {
         if let RewindController::Keyboard { speed, .. } = self {
-            if target.window_state.modifers_state.shift_key() {
+            if ctx.window_state.modifers_state.shift_key() {
                 player.rewind(*speed * 2);
-            } else if target.window_state.modifers_state.control_key() {
+            } else if ctx.window_state.modifers_state.control_key() {
                 player.rewind(*speed / 2);
             } else {
                 player.rewind(*speed);
@@ -64,7 +64,7 @@ impl RewindController {
 
     pub fn handle_window_event(
         &mut self,
-        target: &mut Target,
+        ctx: &mut Context,
         event: &WindowEvent,
         player: &mut MidiPlayer,
     ) {
@@ -73,7 +73,7 @@ impl RewindController {
                 self.handle_keyboard_input(player, event);
             }
             WindowEvent::CursorMoved { position, .. } => {
-                self.handle_cursor_moved(player, &target.window_state, position);
+                self.handle_cursor_moved(player, &ctx.window_state, position);
             }
             _ => {}
         }

--- a/neothesia/src/scene/playing_scene/top_bar.rs
+++ b/neothesia/src/scene/playing_scene/top_bar.rs
@@ -7,7 +7,7 @@ use winit::{
     event::{ElementState, MouseButton, WindowEvent},
 };
 
-use crate::{target::Target, utils::window::WindowState, NeothesiaEvent};
+use crate::{context::Context, utils::window::WindowState, NeothesiaEvent};
 
 use super::{
     animation, rewind_controller::RewindController, PlayingScene, EVENT_CAPTURED, EVENT_IGNORED,
@@ -126,15 +126,15 @@ impl TopBar {
 
     pub fn handle_window_event(
         scene: &mut PlayingScene,
-        target: &mut Target,
+        ctx: &mut Context,
         event: &WindowEvent,
     ) -> bool {
         match &event {
             WindowEvent::MouseInput { state, button, .. } => {
-                return Self::handle_mouse_input(scene, target, state, button);
+                return Self::handle_mouse_input(scene, ctx, state, button);
             }
             WindowEvent::CursorMoved { position, .. } => {
-                Self::handle_cursor_moved(scene, target, position);
+                Self::handle_cursor_moved(scene, ctx, position);
             }
             _ => {}
         }
@@ -144,7 +144,7 @@ impl TopBar {
 
     fn handle_mouse_input(
         scene: &mut PlayingScene,
-        target: &mut Target,
+        ctx: &mut Context,
         state: &ElementState,
         button: &MouseButton,
     ) -> bool {
@@ -159,7 +159,7 @@ impl TopBar {
                     return EVENT_CAPTURED;
                 }
                 Element::BackButton => {
-                    target.proxy.send_event(NeothesiaEvent::MainMenu).ok();
+                    ctx.proxy.send_event(NeothesiaEvent::MainMenu).ok();
                     return EVENT_CAPTURED;
                 }
                 Element::StartTick | Element::EndTick => {
@@ -167,7 +167,7 @@ impl TopBar {
                     return EVENT_CAPTURED;
                 }
                 _ => {
-                    let pos = &target.window_state.cursor_logical_position;
+                    let pos = &ctx.window_state.cursor_logical_position;
 
                     if pos.y > 30.0
                         && pos.y < scene.top_bar.height
@@ -175,8 +175,8 @@ impl TopBar {
                     {
                         scene.rewind_controler.start_mouse_rewind(&mut scene.player);
 
-                        let x = target.window_state.cursor_logical_position.x;
-                        let w = target.window_state.logical_size.width;
+                        let x = ctx.window_state.cursor_logical_position.x;
+                        let w = ctx.window_state.logical_size.width;
 
                         let p = x / w;
                         log::debug!("Progressbar: x:{},p:{}", x, p);
@@ -201,16 +201,12 @@ impl TopBar {
 
     fn handle_cursor_moved(
         scene: &mut PlayingScene,
-        target: &mut Target,
+        ctx: &mut Context,
         position: &PhysicalPosition<f64>,
     ) {
-        let x = position
-            .to_logical::<f32>(target.window_state.scale_factor)
-            .x;
-        let y = position
-            .to_logical::<f32>(target.window_state.scale_factor)
-            .y;
-        let w = target.window_state.logical_size.width;
+        let x = position.to_logical::<f32>(ctx.window_state.scale_factor).x;
+        let y = position.to_logical::<f32>(ctx.window_state.scale_factor).y;
+        let w = ctx.window_state.logical_size.width;
 
         scene.top_bar.hovered = scene.top_bar.hovered(x, y);
 


### PR DESCRIPTION
`Target` is a leftover from when it was representing a `RenderTarget`, this hasn't been the case for years now, it's more of a general app context, so the name should reflect that. One benefit of that is that it abbreviates nicely to `ctx`