### PR TITLE
enable jack support for midir

### DIFF
--- a/midi-io/Cargo.toml
+++ b/midi-io/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-midir = "0.9"
+midir = { version = "0.9", features = ["jack"] }


### PR DESCRIPTION
alsa have some performance issue on black midi. jack slightly better in this case