### PR TITLE
Go back to menu after song is finished

### DIFF
--- a/midi-file/src/playback.rs
+++ b/midi-file/src/playback.rs
@@ -89,6 +89,10 @@ impl PlaybackState {
         self.running = time;
     }
 
+    pub fn is_finished(&self) -> bool {
+        self.time() >= self.length()
+    }
+
     pub fn percentage(&self) -> f32 {
         self.running.as_secs_f32() / self.length().as_secs_f32()
     }

--- a/neothesia/src/scene/playing_scene/midi_player.rs
+++ b/neothesia/src/scene/playing_scene/midi_player.rs
@@ -166,6 +166,10 @@ impl MidiPlayer {
         self.playback.percentage()
     }
 
+    pub fn is_finished(&self) -> bool {
+        self.playback.is_finished()
+    }
+
     pub fn time(&self) -> Duration {
         self.playback.time()
     }

--- a/neothesia/src/scene/playing_scene/mod.rs
+++ b/neothesia/src/scene/playing_scene/mod.rs
@@ -141,6 +141,10 @@ impl Scene for PlayingScene {
 
         self.bg_quad_pipeline.prepare(&ctx.gpu.queue);
         self.fg_quad_pipeline.prepare(&ctx.gpu.queue);
+
+        if self.player.is_finished() {
+            ctx.proxy.send_event(NeothesiaEvent::MainMenu).ok();
+        }
     }
 
     fn render<'pass>(


### PR DESCRIPTION
Kinda based on #172 but working the other way around, let the scene ask the MidiPlayer if the song is finished, rather than the other way around.