### PR TITLE
More robust wgpu backend fallbacks

### DIFF
--- a/neothesia/src/main.rs
+++ b/neothesia/src/main.rs
@@ -287,9 +287,12 @@ impl ApplicationHandler<NeothesiaEvent> for NeothesiaBootstrap {
         let window_state = WindowState::new(&window);
         let size = window.inner_size();
         let window = Arc::new(window);
-        let (gpu, surface) =
-            futures::executor::block_on(Gpu::for_window(window.clone(), size.width, size.height))
-                .unwrap();
+        let (gpu, surface) = futures::executor::block_on(Gpu::for_window(
+            || window.clone().into(),
+            size.width,
+            size.height,
+        ))
+        .unwrap();
 
         let ctx = Context::new(window, window_state, self.1.clone(), gpu);
 
@@ -327,7 +330,7 @@ impl ApplicationHandler<NeothesiaEvent> for NeothesiaBootstrap {
 
 fn main() {
     env_logger::Builder::from_env(
-        env_logger::Env::default().default_filter_or("warn, wgpu_hal=error, oxisynth=error"),
+        env_logger::Env::default().default_filter_or("info, wgpu_hal=error, oxisynth=error"),
     )
     .init();
 

--- a/wgpu-jumpstart/src/instances.rs
+++ b/wgpu-jumpstart/src/instances.rs
@@ -32,7 +32,7 @@ where
 
     pub fn update(&mut self, device: &wgpu::Device, queue: &wgpu::Queue) {
         if self.capacity < self.data.len() {
-            log::warn!(
+            log::trace!(
                 "Dynamically growing instances buffer from {} to {}",
                 self.capacity,
                 self.data.len()


### PR DESCRIPTION
Wgpu backend picking leaves much to be desired, so let's brute force all possible
backend options manually before giving up.

(I got tired of asking people to type in all possible WGPU_BAKEND combinations manually until wgpu runs on their machine, this should be done by wgpu...)