### PR TITLE
Move TextRenderer out of the global context

### DIFF
--- a/neothesia-core/src/render/text/mod.rs
+++ b/neothesia-core/src/render/text/mod.rs
@@ -282,7 +282,7 @@ impl TextRenderer {
         self.queue_buffer(x, y, buffer);
     }
 
-    pub fn queue_fps(&mut self, fps: f64) {
+    pub fn queue_fps(&mut self, fps: f64, y: f32) {
         let text = format!("FPS: {}", fps.round() as u32);
         let mut buffer =
             glyphon::Buffer::new(&mut self.font_system, glyphon::Metrics::new(15.0, 15.0));
@@ -298,7 +298,7 @@ impl TextRenderer {
         self.queue(TextArea {
             buffer,
             left: 0.0,
-            top: 5.0,
+            top: y,
             scale: 1.0,
             bounds: glyphon::TextBounds::default(),
             default_color: glyphon::Color::rgb(255, 255, 255),

--- a/neothesia/src/context.rs
+++ b/neothesia/src/context.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 
 use crate::config::Config;
 use crate::input_manager::InputManager;
-use crate::render::TextRenderer;
 use crate::utils::window::WindowState;
 use crate::{output_manager::OutputManager, NeothesiaEvent, TransformUniform};
+use neothesia_core::utils::fps_ticker;
 use wgpu_jumpstart::{Gpu, Uniform};
 use winit::event_loop::EventLoopProxy;
 
@@ -20,8 +20,6 @@ pub struct Context {
 
     pub transform: Uniform<TransformUniform>,
 
-    pub text_renderer: TextRenderer,
-
     pub output_manager: OutputManager,
     pub input_manager: InputManager,
     pub config: Config,
@@ -30,6 +28,9 @@ pub struct Context {
 
     /// Last frame timestamp
     pub frame_timestamp: std::time::Instant,
+
+    #[cfg(debug_assertions)]
+    pub fps_ticker: fps_ticker::Fps,
 }
 
 impl Drop for Context {
@@ -50,8 +51,6 @@ impl Context {
             TransformUniform::default(),
             wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
         );
-
-        let text_renderer = TextRenderer::new(&gpu);
 
         let iced_manager = IcedManager::new(
             &gpu.adapter,
@@ -75,13 +74,14 @@ impl Context {
             gpu,
             transform: transform_uniform,
 
-            text_renderer,
-
             output_manager: Default::default(),
             input_manager: InputManager::new(proxy.clone()),
             config,
             proxy,
             frame_timestamp: std::time::Instant::now(),
+
+            #[cfg(debug_assertions)]
+            fps_ticker: fps_ticker::Fps::default(),
         }
     }
 

--- a/neothesia/src/scene/playing_scene/top_bar/mod.rs
+++ b/neothesia/src/scene/playing_scene/top_bar/mod.rs
@@ -47,7 +47,7 @@ mod icons {
 }
 
 pub struct TopBar {
-    topbar_expand_animation: Animated<bool, Instant>,
+    pub topbar_expand_animation: Animated<bool, Instant>,
     is_expanded: bool,
 
     settings_animation: Animated<bool, Instant>,


### PR DESCRIPTION
No need for the text rendering to be in the global context. This also allows us to adjust FPS counter position based on scene details like top bar animations.

https://github.com/user-attachments/assets/54c8b052-4bc5-4009-960b-b70d766385ac

