### PR TITLE
Fix text rendering under non-1.0 scale factors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2151,6 +2151,7 @@ name = "neothesia-core"
 version = "0.1.0"
 dependencies = [
  "bytemuck",
+ "dpi",
  "euclid",
  "glyphon",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ unicode-segmentation = "1.12.0"
 
 lilt = "0.8"
 winit = "0.30"
+dpi = "0.1"
 rfd = "0.15"
 cpal = "0.16"
 fluidlite = { version = "0.2", features = ["builtin"] }

--- a/neothesia-cli/src/main.rs
+++ b/neothesia-cli/src/main.rs
@@ -171,7 +171,10 @@ impl Recorder {
         self.quad_renderer_bg.prepare();
         self.quad_renderer_fg.prepare();
 
-        self.text.update((self.width, self.height));
+        self.text.update(
+            neothesia_core::dpi::PhysicalSize::new(self.width, self.height),
+            1.0,
+        );
     }
 
     fn render(

--- a/neothesia-core/Cargo.toml
+++ b/neothesia-core/Cargo.toml
@@ -15,6 +15,7 @@ piano-layout.workspace = true
 midi-file.workspace = true
 profiling.workspace = true
 euclid.workspace = true
+dpi.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # TODO: Port to `objc2`

--- a/neothesia-core/src/lib.rs
+++ b/neothesia-core/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::collapsible_match, clippy::single_match)]
 
+pub use dpi;
 pub use piano_layout;
 pub use wgpu_jumpstart::{Color, Gpu, TransformUniform, Uniform};
 

--- a/neothesia-core/src/render/note_labels/mod.rs
+++ b/neothesia-core/src/render/note_labels/mod.rs
@@ -82,7 +82,8 @@ impl NoteLabels {
     #[profiling::function]
     pub fn update(
         &mut self,
-        logical_size: (u32, u32),
+        physical_size: dpi::PhysicalSize<u32>,
+        scale: f32,
         keyboard: &KeyboardRenderer,
         animation_speed: f32,
         time: f32,
@@ -126,7 +127,7 @@ impl NoteLabels {
             });
         }
 
-        self.text_renderer.update(logical_size);
+        self.text_renderer.update(physical_size, scale);
     }
 
     pub fn render<'rpass>(&'rpass mut self, render_pass: &mut wgpu_jumpstart::RenderPass<'rpass>) {

--- a/neothesia-core/src/render/text/mod.rs
+++ b/neothesia-core/src/render/text/mod.rs
@@ -183,14 +183,20 @@ impl TextRenderer {
         self.text_areas.push(area);
     }
 
-    pub fn update(&mut self, logical_size: (u32, u32)) {
+    pub fn update(&mut self, physical_size: dpi::PhysicalSize<u32>, scale: f32) {
         let shared = &mut *self.shared.borrow_mut();
+
         let elements = self.text_areas.iter().map(|area| glyphon::TextArea {
             buffer: &area.buffer,
-            left: area.left,
-            top: area.top,
-            scale: area.scale,
-            bounds: area.bounds,
+            left: area.left * scale,
+            top: area.top * scale,
+            scale: area.scale * scale,
+            bounds: glyphon::TextBounds {
+                left: (area.bounds.left as f32 * scale) as i32,
+                top: (area.bounds.top as f32 * scale) as i32,
+                right: (area.bounds.right as f32 * scale) as i32,
+                bottom: (area.bounds.bottom as f32 * scale) as i32,
+            },
             default_color: area.default_color,
             custom_glyphs: &[],
         });
@@ -198,8 +204,8 @@ impl TextRenderer {
         shared.viewport.update(
             &self.queue,
             glyphon::Resolution {
-                width: logical_size.0,
-                height: logical_size.1,
+                width: physical_size.width,
+                height: physical_size.height,
             },
         );
 

--- a/neothesia/src/scene/mod.rs
+++ b/neothesia/src/scene/mod.rs
@@ -125,8 +125,10 @@ fn render_nuon(ui: &mut nuon::Ui, nuon_renderer: &mut NuonRenderer, ctx: &mut Co
         }
 
         out.quad_renderer.prepare();
-        out.text_renderer
-            .update(ctx.window_state.logical_size.into());
+        out.text_renderer.update(
+            ctx.window_state.physical_size,
+            ctx.window_state.scale_factor as f32,
+        );
     }
 
     ui.done();

--- a/neothesia/src/scene/playing_scene/mod.rs
+++ b/neothesia/src/scene/playing_scene/mod.rs
@@ -223,7 +223,8 @@ impl Scene for PlayingScene {
             .update(&mut self.quad_renderer_fg, &mut self.text_renderer);
         if let Some(note_labels) = self.note_labels.as_mut() {
             note_labels.update(
-                ctx.window_state.logical_size.into(),
+                ctx.window_state.physical_size,
+                ctx.window_state.scale_factor as f32,
                 self.keyboard.renderer(),
                 ctx.config.animation_speed(),
                 time,
@@ -250,8 +251,10 @@ impl Scene for PlayingScene {
                 .topbar_expand_animation
                 .animate_bool(5.0, 80.0, ctx.frame_timestamp),
         );
-        self.text_renderer
-            .update(ctx.window_state.logical_size.into());
+        self.text_renderer.update(
+            ctx.window_state.physical_size,
+            ctx.window_state.scale_factor as f32,
+        );
 
         if self.player.is_finished() && !self.player.is_paused() {
             ctx.proxy


### PR DESCRIPTION
Before:

<img width="432" height="108" alt="image" src="https://github.com/user-attachments/assets/dc264313-5ef0-4425-b176-e948871b4558" />

After:

<img width="432" height="108" alt="Screenshot From 2025-07-28 00-56-21" src="https://github.com/user-attachments/assets/75642bff-3b52-4eae-9215-bcdfc06d0df8" />
