### PR TITLE
Make key labels transparent black

### DIFF
--- a/neothesia-core/src/render/keyboard/mod.rs
+++ b/neothesia-core/src/render/keyboard/mod.rs
@@ -164,7 +164,7 @@ impl KeyboardRenderer {
                     right: x.round() as i32 + w.round() as i32,
                     bottom: y.round() as i32 + h.round() as i32,
                 },
-                default_color: glyphon::Color::rgb(153, 153, 153),
+                default_color: glyphon::Color::rgba(0, 0, 0, 150),
             });
         }
     }


### PR DESCRIPTION
This makes the labels more clear on pressed keys:

<img width="561" height="266" alt="Screenshot From 2025-12-21 00-36-45" src="https://github.com/user-attachments/assets/977f06c1-5f0c-4fcb-be8b-1f626dad7982" />
