### PR TITLE
Issue/352 prevent unnecessary reconnects

### DIFF
--- a/neothesia/src/input_manager/mod.rs
+++ b/neothesia/src/input_manager/mod.rs
@@ -7,6 +7,7 @@ pub struct InputManager {
     input: midi_io::MidiInputManager,
     tx: EventLoopProxy<NeothesiaEvent>,
     current_connection: Option<midi_io::MidiInputConnection>,
+    current_port_name: Option<String>,
 }
 
 impl InputManager {
@@ -16,6 +17,7 @@ impl InputManager {
             input,
             tx,
             current_connection: None,
+            current_port_name: None,
         }
     }
 
@@ -24,9 +26,25 @@ impl InputManager {
     }
 
     pub fn connect_input(&mut self, port: midi_io::MidiInputPort) {
+        let port_name = port.to_string();
+
+        // Skip reconnect if already connected to same port
+        if self.current_connection.is_some()
+            && self.current_port_name.as_deref() == Some(port_name.as_str())
+        {
+            log::info!("connect_input: already connected to {port_name}, skipping");
+            return;
+        }
+
+        // Explicitly drop previous connection
+        self.current_connection.take();
+        self.current_port_name = Some(port_name.clone());
+
+        log::info!("connect_input: connecting to {port_name}");
+
         let tx = self.tx.clone();
         self.current_connection = midi_io::MidiInputManager::connect_input(port, move |message| {
-            let event = LiveEvent::parse(message).unwrap();
+            let Ok(event) = LiveEvent::parse(message) else { return; };
 
             if let LiveEvent::Midi { channel, message } = event {
                 match message {

--- a/neothesia/src/input_manager/mod.rs
+++ b/neothesia/src/input_manager/mod.rs
@@ -70,39 +70,14 @@ impl InputManager {
         });
     }
 
-    pub fn maybe_reconnect(&mut self, desired: Option<&midi_io::MidiInputPort>) {
-        let Some(port) = desired else { return; };
-
-        // If port exists but we're not connected (or think we are but it vanished), connect.
-        let exists = self.input.has_input_port(port);
-
-        if !exists {
-            // device not present; drop dead connection if it's for this port
-            if self.current_port.as_ref() == Some(port) {
-                self.current_connection.take();
-                self.current_port = None;
-            }
-            return;
-        }
-
-        if self.current_connection.is_none() || self.current_port.as_ref() != Some(port) {
-            self.connect_input(port.clone());
-        }
-    }
-
     pub fn force_reconnect(&mut self) {
         // Drop the connection and clear the "already connected" guard
         self.current_connection.take();
         self.current_port = None;
     }
 
-    pub fn connect_selected_name(&mut self, name: &str) {
-        // Build a port object by name (your midi-io currently uses MidiInputPort(String))
-        self.connect_input(midi_io::MidiInputPort::from_name(name.to_string()));
-    }
-
-        /// Connect to the user's preferred input if it exists; otherwise connect to first available.
-    /// Returns the chosen port name (for storing back into config/UI if you want).
+    // Connect to the user's preferred input if it exists; otherwise connect to first available.
+    // Returns the chosen port name (for storing back into config/UI if you want).
     pub fn connect_preferred_by_name(&mut self, preferred: Option<&str>) -> Option<String> {
         let inputs = self.inputs();
 

--- a/neothesia/src/input_manager/mod.rs
+++ b/neothesia/src/input_manager/mod.rs
@@ -31,16 +31,11 @@ impl InputManager {
         // Skip reconnect if already connected to same port
         if self.current_connection.is_some()
             && self.current_port_name.as_deref() == Some(port_name.as_str())
-        {
-            log::info!("connect_input: already connected to {port_name}, skipping");
-            return;
-        }
+        { return; }
 
         // Explicitly drop previous connection
         self.current_connection.take();
         self.current_port_name = Some(port_name.clone());
-
-        log::info!("connect_input: connecting to {port_name}");
 
         let tx = self.tx.clone();
         self.current_connection = midi_io::MidiInputManager::connect_input(port, move |message| {


### PR DESCRIPTION
# Prevent Unnecessary Reconnects

### Description
This PR stems from the [issue](https://github.com/PolyMeilex/Neothesia/issues/352) I reported around input connections. See the issue for steps to recreate the bug. To fix this, I added a port name to the input manager and check that the port names match before deciding whether or not i should try to reconnect. as well, I added logic to explicitly drop previous connections before attempting to reconnect. Doing these things has led to more stable input manager connections. 

### Key Changes

MIDI input connection lifecycle
- prevent unnecessary reconnects by checking if current connection matches desired connection
- track currently connected input port

Improved MIDI port Identity
- rely on stable ids  via port name instead of connection state 
- add port index mapping to handle multiple ports with identical names

### Testing

1. Start the app
2. Select a midi file to play
3. hit the "play" button // inputs should work as expected
4. hit the "back" button to return to the main menu
5. hit the "play" button to again return to the playing scene.
6. if keyboard inputs still work as expected, you win.