### PR TITLE
update all actions to latest versions

### DIFF
--- a/.github/actions/macos/action.yml
+++ b/.github/actions/macos/action.yml
@@ -14,7 +14,7 @@ runs:
     - name: zip binary
       shell: bash
       run: cd .github/app/ && zip -r app.zip Neothesia.app && cd ../..
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: macos-artifact
         path: .github/app/app.zip

--- a/.github/actions/ubuntu-recorder/action.yml
+++ b/.github/actions/ubuntu-recorder/action.yml
@@ -17,7 +17,7 @@ runs:
     - name: zip binary
       shell: bash
       run: zip -rj app.zip target/release/neothesia-cli
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: ubuntu-recorder-artifact
         path: app.zip

--- a/.github/actions/ubuntu/action.yml
+++ b/.github/actions/ubuntu/action.yml
@@ -17,7 +17,7 @@ runs:
     - name: zip binary
       shell: bash
       run: zip -rj app.zip target/release/neothesia
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: ubuntu-artifact
         path: app.zip

--- a/.github/actions/windows-recorder/action.yml
+++ b/.github/actions/windows-recorder/action.yml
@@ -26,7 +26,7 @@ runs:
     - name: Build Ubuntu Release
       shell: bash
       run: cargo build --release -p neothesia-cli
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: windows-recorder-artifact
         path: target/release/neothesia-cli.exe

--- a/.github/actions/windows/action.yml
+++ b/.github/actions/windows/action.yml
@@ -8,7 +8,7 @@ runs:
     - name: Build Windows Release
       shell: bash
       run: cargo build --release
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: windows-artifact
         path: target/release/neothesia.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   build_ubuntu:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: Build
         uses: ./.github/actions/ubuntu
       - name: ls
@@ -19,7 +19,7 @@ jobs:
   build_ubuntu_recorder:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: Build
         uses: ./.github/actions/ubuntu-recorder
       - name: ls
@@ -28,7 +28,7 @@ jobs:
   build_windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: Build
         uses: ./.github/actions/windows
       - name: ls
@@ -41,7 +41,7 @@ jobs:
       FFMPEG_DOWNLOAD_URL: https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full-shared.7z
       
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: Build
         uses: ./.github/actions/windows-recorder
       - name: ls
@@ -54,7 +54,7 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: 10.12
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: Build
         uses: ./.github/actions/macos
       - name: ls

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,19 +20,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 18
           cache: npm
           cache-dependency-path: ./docs/package.json
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Install dependencies
         working-directory: ./docs
@@ -43,7 +43,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: docs/.vitepress/dist
 
@@ -56,4 +56,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   build_ubuntu:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: Build
         uses: ./.github/actions/ubuntu
       - name: ls
@@ -24,7 +24,7 @@ jobs:
   build_ubuntu_recorder:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: Build
         uses: ./.github/actions/ubuntu-recorder
       - name: ls
@@ -40,7 +40,7 @@ jobs:
   build_windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: Build
         uses: ./.github/actions/windows
       - name: ls
@@ -59,7 +59,7 @@ jobs:
       FFMPEG_DOWNLOAD_URL: https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full-shared.7z
       
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: Build
         uses: ./.github/actions/windows-recorder
       - name: ls
@@ -78,7 +78,7 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: 10.12
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: Build
         uses: ./.github/actions/macos
       - name: ls


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows and composite actions to use the latest major versions of several commonly used GitHub Actions. The main goal is to improve security, stability, and compatibility by moving from version 4 to version 6 (or the latest available) for actions like `actions/checkout`, `actions/upload-artifact`, and others.

The most important changes include:

**Workflow Actions Version Upgrades:**

* Updated all usages of `actions/checkout` from `v4` to `v6` across `build.yml`, `release.yml`, and `docs.yml` workflows for improved security and new features.

* Updated `actions/setup-node` usage from `v4` to `v6` in the documentation workflow for better Node.js environment setup.
* Updated `actions/configure-pages` from `v4` to `v6` and `actions/upload-pages-artifact` from `v3` to `v4` in the docs workflow for improved GitHub Pages integration.

* Updated `actions/deploy-pages` from `v4` to `v5` in the docs deployment step.

**Composite Action Version Upgrades:**

* Updated all usages of `actions/upload-artifact` in composite actions (`.github/actions/*/action.yml`) from `v4` to `v6` to ensure artifacts are handled with the latest features and security patches.

These updates help keep the CI/CD pipeline current and secure by leveraging the latest improvements and fixes in GitHub Actions.