### PR TITLE
synth: pin output stream buffer to 1024 frames

### DIFF
--- a/neothesia-core/src/utils/resources.rs
+++ b/neothesia-core/src/utils/resources.rs
@@ -34,6 +34,16 @@ pub fn default_sf2() -> Option<PathBuf> {
             return Some(path);
         }
 
+        // Development: workspace-root default.sf2 (debug builds only).
+        #[cfg(debug_assertions)]
+        if let Some(path) = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .map(|p| p.join("default.sf2"))
+            && path.exists()
+        {
+            return Some(path);
+        }
+
         let flatpak = PathBuf::from("/app/share/neothesia/default.sf2");
         if flatpak.exists() {
             Some(flatpak)

--- a/neothesia/src/output_manager/synth_backend.rs
+++ b/neothesia/src/output_manager/synth_backend.rs
@@ -5,6 +5,8 @@ use crate::output_manager::OutputDescriptor;
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use midi_file::midly::{self, num::u4};
 
+const OUTPUT_BUFFER_FRAMES: u32 = 1024;
+
 #[cfg(all(feature = "fluid-synth", not(feature = "oxi-synth")))]
 const SAMPLES_SIZE: usize = 1410;
 
@@ -28,7 +30,14 @@ impl SynthBackend {
         let config = device.default_output_config()?;
         let sample_format = config.sample_format();
 
-        let stream_config: cpal::StreamConfig = config.into();
+        let buffer_size = match config.buffer_size() {
+            cpal::SupportedBufferSize::Range { min, max } => {
+                cpal::BufferSize::Fixed(OUTPUT_BUFFER_FRAMES.clamp(*min, *max))
+            }
+            cpal::SupportedBufferSize::Unknown => cpal::BufferSize::Default,
+        };
+        let mut stream_config: cpal::StreamConfig = config.into();
+        stream_config.buffer_size = buffer_size;
 
         Ok(Self {
             _host: host,


### PR DESCRIPTION
On shared-server audio backends (PipeWire/JACK), `BufferSize::Default` adopts the host's current quantum. Opening pro-audio applications (e.g. Bitwig) drops that quantum for low-latency monitoring, which then causes Neothesia's stream to underrun and glitch. Requesting a fixed buffer decouples Neothesia from whatever quantum the server is currently running at.