### PR TITLE
Fix duplicate note playback in Human mode

### DIFF
--- a/neothesia/src/scene/playing_scene/midi_player.rs
+++ b/neothesia/src/scene/playing_scene/midi_player.rs
@@ -380,34 +380,3 @@ impl PlayAlong {
         self.required_notes.is_empty()
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use midi_file::midly::num::u7;
-
-    #[test]
-    fn human_notes_are_not_forwarded_from_the_file() {
-        let note_on = MidiMessage::NoteOn {
-            key: u7::new(60),
-            vel: u7::new(100),
-        };
-        let note_off = MidiMessage::NoteOff {
-            key: u7::new(60),
-            vel: u7::new(0),
-        };
-
-        assert!(!should_forward_human_event(&note_on));
-        assert!(!should_forward_human_event(&note_off));
-    }
-
-    #[test]
-    fn human_controller_events_are_still_forwarded() {
-        let controller = MidiMessage::Controller {
-            controller: u7::new(64),
-            value: u7::new(127),
-        };
-
-        assert!(should_forward_human_event(&controller));
-    }
-}

--- a/neothesia/src/scene/playing_scene/midi_player.rs
+++ b/neothesia/src/scene/playing_scene/midi_player.rs
@@ -70,13 +70,15 @@ impl MidiPlayer {
                         .midi_event(u4::new(channel), event.message);
                 }
                 PlayerConfig::Human => {
-                    // Let's play the sound, in case the user does not want it they can just set
-                    // no-output output in settings
-                    // TODO: Perhaps play on midi-in instead
-                    self.output
-                        .midi_event(u4::new(event.channel), event.message);
                     self.play_along
                         .midi_event(MidiEventSource::File, &event.message);
+
+                    // In Human mode note events from the file are targets for the player,
+                    // not notes to be played by the synthesizer. Keep forwarding controller
+                    // and other non-note events so the track still sounds as intended.
+                    if should_forward_human_event(&event.message) {
+                        self.output.midi_event(u4::new(channel), event.message);
+                    }
                 }
                 PlayerConfig::Mute => {}
             }
@@ -197,14 +199,22 @@ impl MidiPlayer {
         &self.play_along
     }
 
-    pub fn play_along_mut(&mut self) -> &mut PlayAlong {
-        &mut self.play_along
+    pub fn user_midi_event(&mut self, channel: u8, message: &MidiMessage) {
+        self.output.midi_event(u4::new(channel), *message);
+        self.play_along.midi_event(MidiEventSource::User, message);
     }
 }
 
 pub enum MidiEventSource {
     File,
     User,
+}
+
+fn should_forward_human_event(message: &MidiMessage) -> bool {
+    !matches!(
+        message,
+        MidiMessage::NoteOn { .. } | MidiMessage::NoteOff { .. }
+    )
 }
 
 type NoteId = u8;
@@ -368,5 +378,36 @@ impl PlayAlong {
 
     pub fn are_required_keys_pressed(&self) -> bool {
         self.required_notes.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use midi_file::midly::num::u7;
+
+    #[test]
+    fn human_notes_are_not_forwarded_from_the_file() {
+        let note_on = MidiMessage::NoteOn {
+            key: u7::new(60),
+            vel: u7::new(100),
+        };
+        let note_off = MidiMessage::NoteOff {
+            key: u7::new(60),
+            vel: u7::new(0),
+        };
+
+        assert!(!should_forward_human_event(&note_on));
+        assert!(!should_forward_human_event(&note_off));
+    }
+
+    #[test]
+    fn human_controller_events_are_still_forwarded() {
+        let controller = MidiMessage::Controller {
+            controller: u7::new(64),
+            value: u7::new(127),
+        };
+
+        assert!(should_forward_human_event(&controller));
     }
 }

--- a/neothesia/src/scene/playing_scene/mod.rs
+++ b/neothesia/src/scene/playing_scene/mod.rs
@@ -301,10 +301,8 @@ impl Scene for PlayingScene {
         super::handle_nuon_window_event(&mut self.nuon, event, ctx);
     }
 
-    fn midi_event(&mut self, _ctx: &mut Context, _channel: u8, message: &MidiMessage) {
-        self.player
-            .play_along_mut()
-            .midi_event(midi_player::MidiEventSource::User, message);
+    fn midi_event(&mut self, _ctx: &mut Context, channel: u8, message: &MidiMessage) {
+        self.player.user_midi_event(channel, message);
         self.keyboard.user_midi_event(message);
     }
 }


### PR DESCRIPTION
Stop forwarding file note-on and note-off events to the output while a Human track waits for player input. Route actual user MIDI events to the active output so notes sound only when the player presses them, while preserving controller events. Add regression tests for both behaviors.