### PR TITLE
Play test piano config in Settings

### DIFF
--- a/midi-io/src/lib.rs
+++ b/midi-io/src/lib.rs
@@ -75,35 +75,40 @@ impl MidiInputManager {
             .collect()
     }
 
-    pub fn connect_input<F>(port: MidiInputPort, mut callback: F) -> Option<MidiInputConnection>
+    pub fn connect_input<F>(
+        port: MidiInputPort,
+        mut callback: F,
+    ) -> Option<(MidiInputPort, MidiInputConnection)>
     where
         F: FnMut(&[u8]) + Send + 'static,
     {
         let input = midir::MidiInput::new("MidiIo-in").unwrap();
 
-        let port = input.ports().into_iter().find(|info| {
+        let midir_port = input.ports().into_iter().find(|info| {
             input
                 .port_name(info)
                 .ok()
                 .map(|name| name == port.0)
                 .unwrap_or(false)
-        });
+        })?;
 
-        port.and_then(move |port| {
-            input
-                .connect(
-                    &port,
-                    "MidiIo-in-conn",
-                    move |_, data, _| {
-                        callback(data);
-                        //
-                    },
-                    (),
-                )
-                .inspect_err(|err| log::error!("MIDI-in connection fail: {err}"))
-                .ok()
-        })
-        .map(MidiInputConnection)
+        Some((
+            port.clone(),
+            MidiInputConnection(
+                input
+                    .connect(
+                        &midir_port,
+                        "MidiIo-in-conn",
+                        move |_, data, _| {
+                            callback(data);
+                            //
+                        },
+                        (),
+                    )
+                    .inspect_err(|err| log::error!("MIDI-in connection fail: {err}"))
+                    .ok()?,
+            ),
+        ))
     }
 }
 

--- a/neothesia/src/input_manager/mod.rs
+++ b/neothesia/src/input_manager/mod.rs
@@ -6,7 +6,7 @@ use crate::NeothesiaEvent;
 pub struct InputManager {
     input: midi_io::MidiInputManager,
     tx: EventLoopProxy<NeothesiaEvent>,
-    current_connection: Option<midi_io::MidiInputConnection>,
+    current_connection: Option<(midi_io::MidiInputPort, midi_io::MidiInputConnection)>,
 }
 
 impl InputManager {
@@ -25,6 +25,12 @@ impl InputManager {
 
     pub fn connect_input(&mut self, port: midi_io::MidiInputPort) {
         let tx = self.tx.clone();
+
+        if let Some((current, _)) = self.current_connection.as_ref()
+            && current == &port
+        {
+            return;
+        }
 
         // Close the connection first, as Windows does not like it when we hold 2 connections
         self.current_connection = None;

--- a/neothesia/src/scene/menu_scene/mod.rs
+++ b/neothesia/src/scene/menu_scene/mod.rs
@@ -22,6 +22,7 @@ use winit::{
 };
 
 use crate::{NeothesiaEvent, context::Context, icons, scene::Scene, song::Song};
+use midi_file::midly::MidiMessage;
 
 use super::NuonRenderer;
 
@@ -75,6 +76,7 @@ pub struct MenuScene {
 
     tracks_scroll: nuon::ScrollState,
     settings_scroll: nuon::ScrollState,
+    settings_test_key: Option<u8>,
     popup: Popup,
 }
 
@@ -109,6 +111,7 @@ impl MenuScene {
             nuon: nuon::Ui::new(),
             tracks_scroll: nuon::ScrollState::new(),
             settings_scroll: nuon::ScrollState::new(),
+            settings_test_key: None,
             popup: Popup::None,
         }
     }
@@ -319,6 +322,10 @@ impl Scene for MenuScene {
     }
 
     fn window_event(&mut self, ctx: &mut Context, event: &WindowEvent) {
+        if event.left_mouse_released() {
+            self.release_settings_test_key(ctx);
+        }
+
         if let WindowEvent::MouseWheel { delta, .. } = event {
             match delta {
                 winit::event::MouseScrollDelta::LineDelta(_, y) => {
@@ -383,6 +390,7 @@ impl Scene for MenuScene {
             }
             Page::Settings => {
                 if event.key_pressed(Key::Named(NamedKey::Escape)) {
+                    self.release_settings_test_key(ctx);
                     self.state.go_back();
                 }
             }
@@ -396,5 +404,37 @@ impl Scene for MenuScene {
                 }
             }
         }
+    }
+}
+
+impl MenuScene {
+    fn press_settings_test_key(&mut self, ctx: &mut Context, key: u8) {
+        if self.settings_test_key == Some(key) {
+            return;
+        }
+
+        self.release_settings_test_key(ctx);
+        self.settings_test_key = Some(key);
+        ctx.output_manager.connection().midi_event(
+            0.into(),
+            MidiMessage::NoteOn {
+                key: key.into(),
+                vel: 100.into(),
+            },
+        );
+    }
+
+    fn release_settings_test_key(&mut self, ctx: &Context) {
+        let Some(key) = self.settings_test_key.take() else {
+            return;
+        };
+
+        ctx.output_manager.connection().midi_event(
+            0.into(),
+            MidiMessage::NoteOff {
+                key: key.into(),
+                vel: 0.into(),
+            },
+        );
     }
 }

--- a/neothesia/src/scene/menu_scene/mod.rs
+++ b/neothesia/src/scene/menu_scene/mod.rs
@@ -11,7 +11,7 @@ use neo_btn::{neo_btn, neo_btn_icon};
 mod settings;
 mod tracks;
 
-use std::{future::Future, time::Duration};
+use std::{collections::HashSet, future::Future, time::Duration};
 
 use crate::utils::{BoxFuture, noop_waker_ref, window::WinitEvent};
 use neothesia_core::render::{BgPipeline, ImageIdentifier, QuadRenderer, TextRenderer};
@@ -77,6 +77,8 @@ pub struct MenuScene {
     tracks_scroll: nuon::ScrollState,
     settings_scroll: nuon::ScrollState,
     settings_test_key: Option<u8>,
+    settings_input_keys: HashSet<u8>,
+    settings_input_connected: bool,
     popup: Popup,
 }
 
@@ -112,6 +114,8 @@ impl MenuScene {
             tracks_scroll: nuon::ScrollState::new(),
             settings_scroll: nuon::ScrollState::new(),
             settings_test_key: None,
+            settings_input_keys: HashSet::new(),
+            settings_input_connected: false,
             popup: Popup::None,
         }
     }
@@ -405,6 +409,18 @@ impl Scene for MenuScene {
             }
         }
     }
+
+    fn midi_event(&mut self, _ctx: &mut Context, _channel: u8, message: &MidiMessage) {
+        match message {
+            MidiMessage::NoteOn { key, .. } => {
+                self.settings_input_keys.insert(key.as_int());
+            }
+            MidiMessage::NoteOff { key, .. } => {
+                self.settings_input_keys.remove(&key.as_int());
+            }
+            _ => {}
+        }
+    }
 }
 
 impl MenuScene {
@@ -436,5 +452,9 @@ impl MenuScene {
                 vel: 0.into(),
             },
         );
+    }
+
+    fn settings_key_is_pressed(&self, key: u8) -> bool {
+        self.settings_test_key == Some(key) || self.settings_input_keys.contains(&key)
     }
 }

--- a/neothesia/src/scene/menu_scene/mod.rs
+++ b/neothesia/src/scene/menu_scene/mod.rs
@@ -59,6 +59,25 @@ impl Popup {
     }
 }
 
+#[derive(Default, Debug)]
+struct MidiInputState {
+    input_keys: HashSet<u8>,
+}
+
+impl MidiInputState {
+    fn note_on(&mut self, note: u8) {
+        self.input_keys.insert(note);
+    }
+
+    fn note_off(&mut self, note: u8) {
+        self.input_keys.remove(&note);
+    }
+
+    fn is_pressed(&self, note: u8) -> bool {
+        self.input_keys.contains(&note)
+    }
+}
+
 pub struct MenuScene {
     bg_pipeline: BgPipeline,
     text_renderer: TextRenderer,
@@ -76,9 +95,7 @@ pub struct MenuScene {
 
     tracks_scroll: nuon::ScrollState,
     settings_scroll: nuon::ScrollState,
-    settings_test_key: Option<u8>,
-    settings_input_keys: HashSet<u8>,
-    settings_input_connected: bool,
+    midi_input_state: MidiInputState,
     popup: Popup,
 }
 
@@ -113,9 +130,7 @@ impl MenuScene {
             nuon: nuon::Ui::new(),
             tracks_scroll: nuon::ScrollState::new(),
             settings_scroll: nuon::ScrollState::new(),
-            settings_test_key: None,
-            settings_input_keys: HashSet::new(),
-            settings_input_connected: false,
+            midi_input_state: MidiInputState::default(),
             popup: Popup::None,
         }
     }
@@ -326,10 +341,6 @@ impl Scene for MenuScene {
     }
 
     fn window_event(&mut self, ctx: &mut Context, event: &WindowEvent) {
-        if event.left_mouse_released() {
-            self.release_settings_test_key(ctx);
-        }
-
         if let WindowEvent::MouseWheel { delta, .. } = event {
             match delta {
                 winit::event::MouseScrollDelta::LineDelta(_, y) => {
@@ -394,7 +405,6 @@ impl Scene for MenuScene {
             }
             Page::Settings => {
                 if event.key_pressed(Key::Named(NamedKey::Escape)) {
-                    self.release_settings_test_key(ctx);
                     self.state.go_back();
                 }
             }
@@ -410,51 +420,21 @@ impl Scene for MenuScene {
         }
     }
 
-    fn midi_event(&mut self, _ctx: &mut Context, _channel: u8, message: &MidiMessage) {
+    fn midi_event(&mut self, ctx: &mut Context, channel: u8, message: &MidiMessage) {
         match message {
             MidiMessage::NoteOn { key, .. } => {
-                self.settings_input_keys.insert(key.as_int());
+                self.midi_input_state.note_on(key.as_int());
+                ctx.output_manager
+                    .connection()
+                    .midi_event(channel.into(), *message);
             }
             MidiMessage::NoteOff { key, .. } => {
-                self.settings_input_keys.remove(&key.as_int());
+                self.midi_input_state.note_off(key.as_int());
+                ctx.output_manager
+                    .connection()
+                    .midi_event(channel.into(), *message);
             }
             _ => {}
         }
-    }
-}
-
-impl MenuScene {
-    fn press_settings_test_key(&mut self, ctx: &mut Context, key: u8) {
-        if self.settings_test_key == Some(key) {
-            return;
-        }
-
-        self.release_settings_test_key(ctx);
-        self.settings_test_key = Some(key);
-        ctx.output_manager.connection().midi_event(
-            0.into(),
-            MidiMessage::NoteOn {
-                key: key.into(),
-                vel: 100.into(),
-            },
-        );
-    }
-
-    fn release_settings_test_key(&mut self, ctx: &Context) {
-        let Some(key) = self.settings_test_key.take() else {
-            return;
-        };
-
-        ctx.output_manager.connection().midi_event(
-            0.into(),
-            MidiMessage::NoteOff {
-                key: key.into(),
-                vel: 0.into(),
-            },
-        );
-    }
-
-    fn settings_key_is_pressed(&self, key: u8) -> bool {
-        self.settings_test_key == Some(key) || self.settings_input_keys.contains(&key)
     }
 }

--- a/neothesia/src/scene/menu_scene/settings.rs
+++ b/neothesia/src/scene/menu_scene/settings.rs
@@ -19,6 +19,10 @@ fn button() -> nuon::Button {
 
 impl super::MenuScene {
     pub fn settings_page_ui(&mut self, ctx: &mut Context, ui: &mut nuon::Ui) {
+        // Establish the selected output before the test piano is used, so the first note does
+        // not need to create an output connection or load a SoundFont.
+        super::state::connect_output(&self.state, ctx);
+
         let win_w = ctx.window_state.logical_size.width;
         let win_h = ctx.window_state.logical_size.height;
 
@@ -95,7 +99,7 @@ impl super::MenuScene {
                 nuon::translate().y(10.0).add_to_current(ui);
 
                 let keyboard_h = 100.0;
-                self::keyboard_layout_preview(ctx, body_w, keyboard_h, ui);
+                self.keyboard_layout_preview(ctx, body_w, keyboard_h, ui);
                 nuon::translate().y(keyboard_h).add_to_current(ui);
 
                 nuon::settings_section("Render")
@@ -202,6 +206,7 @@ impl super::MenuScene {
                     ctx.config
                         .set_output(output.is_not_dummy().then(|| output.to_string()));
                     data.selected_output = Some(output.clone());
+                    super::state::connect_output(data, ctx);
                     self.popup.close();
                 }
             });
@@ -354,52 +359,115 @@ impl super::MenuScene {
     }
 }
 
-fn keyboard_layout_preview(ctx: &Context, keyboard_w: f32, keyboard_h: f32, ui: &mut nuon::Ui) {
-    nuon::quad()
-        .size(keyboard_w, keyboard_h)
-        .color([255; 3])
-        .border_radius([7.0; 4])
-        .build(ui);
+impl super::MenuScene {
+    fn keyboard_layout_preview(
+        &mut self,
+        ctx: &mut Context,
+        keyboard_w: f32,
+        keyboard_h: f32,
+        ui: &mut nuon::Ui,
+    ) {
+        nuon::quad()
+            .size(keyboard_w, keyboard_h)
+            .color([255; 3])
+            .border_radius([7.0; 4])
+            .build(ui);
 
-    let range = piano_layout::KeyboardRange::new(ctx.config.piano_range());
+        let range = piano_layout::KeyboardRange::new(ctx.config.piano_range());
 
-    let white_count = range.white_count();
-    let neutral_width = keyboard_w / white_count as f32;
-    let neutral_height = keyboard_h;
+        let white_count = range.white_count();
+        let neutral_width = keyboard_w / white_count as f32;
+        let neutral_height = keyboard_h;
 
-    let layout = piano_layout::KeyboardLayout::from_range(
-        piano_layout::Sizing::new(neutral_width, neutral_height),
-        range,
-    );
+        let layout = piano_layout::KeyboardLayout::from_range(
+            piano_layout::Sizing::new(neutral_width, neutral_height),
+            range,
+        );
 
-    let mut neutral = layout
-        .keys
-        .iter()
-        .filter(|key| key.kind().is_neutral())
-        .peekable();
+        let mut neutral = layout
+            .keys
+            .iter()
+            .filter(|key| key.kind().is_neutral())
+            .peekable();
 
-    while let Some(key) = neutral.next() {
-        if neutral.peek().is_some() {
+        while let Some(key) = neutral.next() {
+            if neutral.peek().is_some() {
+                nuon::quad()
+                    .x(key.x() + key.width())
+                    .y(0.0)
+                    .size(1.0, key.height())
+                    .color([150; 3])
+                    .build(ui);
+            }
+        }
+
+        if let Some(note) = self.settings_test_key {
+            if let Some(key) = layout.keys.iter().find(|key| {
+                key.kind().is_neutral() && layout.range.start() + key.id() as u8 == note
+            }) {
+                nuon::quad()
+                    .pos(key.x(), 0.0)
+                    .size(key.width(), key.height())
+                    .color([122, 104, 168])
+                    .build(ui);
+            }
+        }
+
+        for key in layout.keys.iter().filter(|key| key.kind().is_sharp()) {
+            let note = layout.range.start() + key.id() as u8;
             nuon::quad()
-                .x(key.x() + key.width())
-                .y(0.0)
-                .size(1.0, key.height())
-                .color([150; 3])
+                .pos(key.x(), 0.0)
+                .size(key.width(), key.height())
+                .color(if self.settings_test_key == Some(note) {
+                    [122, 104, 168]
+                } else {
+                    [0; 3]
+                })
                 .build(ui);
         }
-    }
 
-    for key in layout.keys.iter().filter(|key| key.kind().is_sharp()) {
-        let x = key.x();
-        let y = 0.0;
-        let width = key.width();
-        let height = key.height();
+        let mut hovered_key = None;
+        let mut started_press = false;
 
-        nuon::quad()
-            .pos(x, y)
-            .size(width, height)
-            .color([0; 3])
-            .build(ui);
+        for key in layout.keys.iter().filter(|key| key.kind().is_sharp()) {
+            let note = layout.range.start() + key.id() as u8;
+            let event = nuon::click_area(format!("settings-preview-key-{note}"))
+                .pos(key.x(), 0.0)
+                .size(key.width(), key.height())
+                .build(ui);
+
+            if event.is_press_start() {
+                started_press = true;
+                self.press_settings_test_key(ctx, note);
+            }
+
+            if event.is_hovered() {
+                hovered_key = Some(note);
+            }
+        }
+
+        for key in layout.keys.iter().filter(|key| key.kind().is_neutral()) {
+            let note = layout.range.start() + key.id() as u8;
+            let event = nuon::click_area(format!("settings-preview-key-{note}"))
+                .pos(key.x(), 0.0)
+                .size(key.width(), key.height())
+                .build(ui);
+
+            if event.is_press_start() {
+                started_press = true;
+                self.press_settings_test_key(ctx, note);
+            }
+
+            if hovered_key.is_none() && event.is_hovered() {
+                hovered_key = Some(note);
+            }
+        }
+
+        if !started_press && ctx.window_state.left_mouse_btn && self.settings_test_key.is_some() {
+            if let Some(note) = hovered_key {
+                self.press_settings_test_key(ctx, note);
+            }
+        }
     }
 }
 

--- a/neothesia/src/scene/menu_scene/settings.rs
+++ b/neothesia/src/scene/menu_scene/settings.rs
@@ -22,6 +22,10 @@ impl super::MenuScene {
         // Establish the selected output before the test piano is used, so the first note does
         // not need to create an output connection or load a SoundFont.
         super::state::connect_output(&self.state, ctx);
+        if !self.settings_input_connected {
+            super::state::connect_input(&self.state, ctx);
+            self.settings_input_connected = true;
+        }
 
         let win_w = ctx.window_state.logical_size.width;
         let win_h = ctx.window_state.logical_size.height;
@@ -339,6 +343,8 @@ impl super::MenuScene {
                 {
                     ctx.config.set_input(Some(&input));
                     data.selected_input = Some(input.clone());
+                    super::state::connect_input(data, ctx);
+                    self.settings_input_connected = true;
                     self.popup.close();
                 }
             });
@@ -401,10 +407,9 @@ impl super::MenuScene {
             }
         }
 
-        if let Some(note) = self.settings_test_key {
-            if let Some(key) = layout.keys.iter().find(|key| {
-                key.kind().is_neutral() && layout.range.start() + key.id() as u8 == note
-            }) {
+        for key in layout.keys.iter().filter(|key| key.kind().is_neutral()) {
+            let note = layout.range.start() + key.id() as u8;
+            if self.settings_key_is_pressed(note) {
                 nuon::quad()
                     .pos(key.x(), 0.0)
                     .size(key.width(), key.height())
@@ -418,7 +423,7 @@ impl super::MenuScene {
             nuon::quad()
                 .pos(key.x(), 0.0)
                 .size(key.width(), key.height())
-                .color(if self.settings_test_key == Some(note) {
+                .color(if self.settings_key_is_pressed(note) {
                     [122, 104, 168]
                 } else {
                     [0; 3]

--- a/neothesia/src/scene/menu_scene/settings.rs
+++ b/neothesia/src/scene/menu_scene/settings.rs
@@ -6,6 +6,7 @@ use crate::{
     utils::BoxFuture,
 };
 use nuon::TextJustify;
+use piano_layout::Key;
 
 use super::UiState;
 
@@ -19,13 +20,8 @@ fn button() -> nuon::Button {
 
 impl super::MenuScene {
     pub fn settings_page_ui(&mut self, ctx: &mut Context, ui: &mut nuon::Ui) {
-        // Establish the selected output before the test piano is used, so the first note does
-        // not need to create an output connection or load a SoundFont.
-        super::state::connect_output(&self.state, ctx);
-        if !self.settings_input_connected {
-            super::state::connect_input(&self.state, ctx);
-            self.settings_input_connected = true;
-        }
+        // Establish the selected output/input connection
+        super::state::connect_io(&self.state, ctx);
 
         let win_w = ctx.window_state.logical_size.width;
         let win_h = ctx.window_state.logical_size.height;
@@ -210,7 +206,6 @@ impl super::MenuScene {
                     ctx.config
                         .set_output(output.is_not_dummy().then(|| output.to_string()));
                     data.selected_output = Some(output.clone());
-                    super::state::connect_output(data, ctx);
                     self.popup.close();
                 }
             });
@@ -343,8 +338,6 @@ impl super::MenuScene {
                 {
                     ctx.config.set_input(Some(&input));
                     data.selected_input = Some(input.clone());
-                    super::state::connect_input(data, ctx);
-                    self.settings_input_connected = true;
                     self.popup.close();
                 }
             });
@@ -368,7 +361,7 @@ impl super::MenuScene {
 impl super::MenuScene {
     fn keyboard_layout_preview(
         &mut self,
-        ctx: &mut Context,
+        ctx: &Context,
         keyboard_w: f32,
         keyboard_h: f32,
         ui: &mut nuon::Ui,
@@ -390,6 +383,63 @@ impl super::MenuScene {
             range,
         );
 
+        let mut build_key = |ui: &mut nuon::Ui, key: &Key| {
+            let note = layout.range.start() + key.id() as u8;
+            let x = key.x();
+            let y = 0.0;
+            let width = key.width();
+            let height = key.height();
+
+            let event = nuon::click_area(format!("settings-preview-key-{note}"))
+                .pos(key.x(), 0.0)
+                .size(key.width(), key.height())
+                .build(ui);
+
+            if event.is_press_start() {
+                ctx.output_manager.connection().midi_event(
+                    0.into(),
+                    midi_file::midly::MidiMessage::NoteOn {
+                        key: note.into(),
+                        vel: 100.into(),
+                    },
+                );
+                self.midi_input_state.note_on(note);
+            }
+            if event.is_press_end() {
+                ctx.output_manager.connection().midi_event(
+                    0.into(),
+                    midi_file::midly::MidiMessage::NoteOff {
+                        key: note.into(),
+                        vel: 0.into(),
+                    },
+                );
+                self.midi_input_state.note_off(note);
+            }
+
+            nuon::quad()
+                .pos(x, y)
+                .size(width, height)
+                .color(if self.midi_input_state.is_pressed(note) {
+                    [122, 104, 168, 255]
+                } else if key.kind().is_sharp() {
+                    [0, 0, 0, 255]
+                } else {
+                    [0; 4]
+                })
+                .build(ui);
+        };
+
+        nuon::layer().build(ui, |ui| {
+            for key in layout.keys.iter().filter(|key| key.kind().is_sharp()) {
+                build_key(ui, key);
+            }
+        });
+
+        for key in layout.keys.iter().filter(|key| key.kind().is_neutral()) {
+            build_key(ui, key);
+        }
+
+        // Key borders
         let mut neutral = layout
             .keys
             .iter()
@@ -404,73 +454,6 @@ impl super::MenuScene {
                     .size(1.0, key.height())
                     .color([150; 3])
                     .build(ui);
-            }
-        }
-
-        for key in layout.keys.iter().filter(|key| key.kind().is_neutral()) {
-            let note = layout.range.start() + key.id() as u8;
-            if self.settings_key_is_pressed(note) {
-                nuon::quad()
-                    .pos(key.x(), 0.0)
-                    .size(key.width(), key.height())
-                    .color([122, 104, 168])
-                    .build(ui);
-            }
-        }
-
-        for key in layout.keys.iter().filter(|key| key.kind().is_sharp()) {
-            let note = layout.range.start() + key.id() as u8;
-            nuon::quad()
-                .pos(key.x(), 0.0)
-                .size(key.width(), key.height())
-                .color(if self.settings_key_is_pressed(note) {
-                    [122, 104, 168]
-                } else {
-                    [0; 3]
-                })
-                .build(ui);
-        }
-
-        let mut hovered_key = None;
-        let mut started_press = false;
-
-        for key in layout.keys.iter().filter(|key| key.kind().is_sharp()) {
-            let note = layout.range.start() + key.id() as u8;
-            let event = nuon::click_area(format!("settings-preview-key-{note}"))
-                .pos(key.x(), 0.0)
-                .size(key.width(), key.height())
-                .build(ui);
-
-            if event.is_press_start() {
-                started_press = true;
-                self.press_settings_test_key(ctx, note);
-            }
-
-            if event.is_hovered() {
-                hovered_key = Some(note);
-            }
-        }
-
-        for key in layout.keys.iter().filter(|key| key.kind().is_neutral()) {
-            let note = layout.range.start() + key.id() as u8;
-            let event = nuon::click_area(format!("settings-preview-key-{note}"))
-                .pos(key.x(), 0.0)
-                .size(key.width(), key.height())
-                .build(ui);
-
-            if event.is_press_start() {
-                started_press = true;
-                self.press_settings_test_key(ctx, note);
-            }
-
-            if hovered_key.is_none() && event.is_hovered() {
-                hovered_key = Some(note);
-            }
-        }
-
-        if !started_press && ctx.window_state.left_mouse_btn && self.settings_test_key.is_some() {
-            if let Some(note) = hovered_key {
-                self.press_settings_test_key(ctx, note);
             }
         }
     }

--- a/neothesia/src/scene/menu_scene/state.rs
+++ b/neothesia/src/scene/menu_scene/state.rs
@@ -124,7 +124,10 @@ pub fn connect_output(data: &UiState, ctx: &mut Context) {
 
 fn connect_io(data: &UiState, ctx: &mut Context) {
     connect_output(data, ctx);
+    connect_input(data, ctx);
+}
 
+pub fn connect_input(data: &UiState, ctx: &mut Context) {
     if let Some(port) = data.selected_input.clone() {
         ctx.input_manager.connect_input(port);
     }

--- a/neothesia/src/scene/menu_scene/state.rs
+++ b/neothesia/src/scene/menu_scene/state.rs
@@ -107,7 +107,7 @@ pub enum Page {
     TrackSelection,
 }
 
-pub fn connect_output(data: &UiState, ctx: &mut Context) {
+pub fn connect_io(data: &UiState, ctx: &mut Context) {
     if let Some(out) = data.selected_output.clone() {
         let out = match out {
             #[cfg(feature = "synth")]
@@ -120,14 +120,7 @@ pub fn connect_output(data: &UiState, ctx: &mut Context) {
             .connection()
             .set_gain(ctx.config.audio_gain());
     }
-}
 
-fn connect_io(data: &UiState, ctx: &mut Context) {
-    connect_output(data, ctx);
-    connect_input(data, ctx);
-}
-
-pub fn connect_input(data: &UiState, ctx: &mut Context) {
     if let Some(port) = data.selected_input.clone() {
         ctx.input_manager.connect_input(port);
     }

--- a/neothesia/src/scene/menu_scene/state.rs
+++ b/neothesia/src/scene/menu_scene/state.rs
@@ -107,7 +107,7 @@ pub enum Page {
     TrackSelection,
 }
 
-fn connect_io(data: &UiState, ctx: &mut Context) {
+pub fn connect_output(data: &UiState, ctx: &mut Context) {
     if let Some(out) = data.selected_output.clone() {
         let out = match out {
             #[cfg(feature = "synth")]
@@ -120,6 +120,10 @@ fn connect_io(data: &UiState, ctx: &mut Context) {
             .connection()
             .set_gain(ctx.config.audio_gain());
     }
+}
+
+fn connect_io(data: &UiState, ctx: &mut Context) {
+    connect_output(data, ctx);
 
     if let Some(port) = data.selected_input.clone() {
         ctx.input_manager.connect_input(port);

--- a/nuon/src/lib.rs
+++ b/nuon/src/lib.rs
@@ -866,6 +866,10 @@ impl ClickAreaEvent {
         matches!(self, ClickAreaEvent::PressStart)
     }
 
+    pub fn is_press_end(&self) -> bool {
+        matches!(self, ClickAreaEvent::PressEnd { .. })
+    }
+
     pub fn is_hovered(&self) -> bool {
         matches!(self, ClickAreaEvent::Idle { hovered: true, .. })
     }
@@ -959,7 +963,7 @@ impl ClickArea {
             ClickAreaEvent::PressEnd { clicked: mouseover }
         } else {
             ClickAreaEvent::Idle {
-                hovered: mouseover,
+                hovered: mouseover && ui.active.is_none(),
                 pressed,
             }
         }

--- a/nuon/src/lib.rs
+++ b/nuon/src/lib.rs
@@ -959,7 +959,7 @@ impl ClickArea {
             ClickAreaEvent::PressEnd { clicked: mouseover }
         } else {
             ClickAreaEvent::Idle {
-                hovered: mouseover && ui.active.is_none(),
+                hovered: mouseover,
                 pressed,
             }
         }


### PR DESCRIPTION
Hi, first of all, thanks for Neothesia. I do have Synthesia, I paid for a license, but being not open source makes it  harder to contribute and improve. Neothesia is great. This is my first feature/change proposal, I am not sure yet the contributor process, so please be patient.

I am suggesting that the piano in the Settings page be playable so that the input/output configuration can be quickly tested. Changing input or output or soundfont or other parameters, I thought it could be useful to test the piano visually with your mouse. Please let me know if you find useful.

p.s.: I just realized it was not playing (or it could play) when pressing the USB-connected piano, so I a added in a new commit.