### PR TITLE
feat(pc-keyboard): Octave shift on `z`/`x` press & layout independent key handling

### DIFF
--- a/neothesia-core/src/config/mod.rs
+++ b/neothesia-core/src/config/mod.rs
@@ -5,8 +5,8 @@ mod model;
 pub use model::ColorSchemaV1;
 use model::{
     AppearanceConfig, AppearanceConfigV1, DevicesConfig, DevicesConfigV1, History, HistoryV1,
-    LayoutConfig, LayoutConfigV1, Model, PlaybackConfig, PlaybackConfigV1, SynthConfig,
-    SynthConfigV1, WaterfallConfig, WaterfallConfigV1,
+    LayoutConfig, LayoutConfigV1, Model, PcKeyboardConfig, PcKeyboardConfigV1, PlaybackConfig,
+    PlaybackConfigV1, SynthConfig, SynthConfigV1, WaterfallConfig, WaterfallConfigV1,
 };
 
 fn ron_options() -> ron::Options {
@@ -44,6 +44,7 @@ impl Model {
             synth,
             keyboard_layout,
             appearance,
+            pc_keyboard,
         } = config;
 
         Self {
@@ -54,6 +55,7 @@ impl Model {
             keyboard_layout: LayoutConfig::V1(keyboard_layout),
             devices: DevicesConfig::V1(devices),
             appearance: AppearanceConfig::V1(appearance),
+            pc_keyboard: PcKeyboardConfig::V1(pc_keyboard),
         }
     }
 
@@ -80,6 +82,9 @@ impl Model {
             keyboard_layout: match self.keyboard_layout {
                 LayoutConfig::V1(v) => v,
             },
+            pc_keyboard: match self.pc_keyboard {
+                PcKeyboardConfig::V1(v) => v,
+            },
         }
     }
 }
@@ -93,6 +98,7 @@ pub struct Config {
     synth: SynthConfigV1,
     history: HistoryV1,
     keyboard_layout: LayoutConfigV1,
+    pc_keyboard: PcKeyboardConfigV1,
 }
 
 impl Default for Config {
@@ -253,6 +259,21 @@ impl Config {
 
     pub fn set_speed_multiplier(&mut self, speed_multiplier: f32) {
         self.playback.speed_multiplier = speed_multiplier.max(0.0);
+    }
+
+    pub fn pc_keyboard_octave(&self) -> u8 {
+        self.pc_keyboard.octave_shift.min(10)
+    }
+
+    pub fn pc_keyboard_shift_octave_up(&mut self) {
+        self.pc_keyboard.octave_shift += 1;
+    }
+
+    pub fn pc_keyboard_shift_octave_down(&mut self) {
+        if self.pc_keyboard.octave_shift == 0 {
+            return;
+        }
+        self.pc_keyboard.octave_shift -= 1;
     }
 
     pub fn save(&self) {

--- a/neothesia-core/src/config/model.rs
+++ b/neothesia-core/src/config/model.rs
@@ -19,6 +19,8 @@ pub struct Model {
     pub devices: DevicesConfig,
     #[serde(default)]
     pub appearance: AppearanceConfig,
+    #[serde(default)]
+    pub pc_keyboard: PcKeyboardConfig,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -195,6 +197,25 @@ impl Default for AppearanceConfig {
     }
 }
 
+#[derive(Serialize, Deserialize, Clone)]
+pub struct PcKeyboardConfigV1 {
+    #[serde(default = "default_octave_shift")]
+    pub octave_shift: u8,
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum PcKeyboardConfig {
+    V1(PcKeyboardConfigV1),
+}
+
+impl Default for PcKeyboardConfig {
+    fn default() -> Self {
+        Self::V1(PcKeyboardConfigV1 {
+            octave_shift: default_octave_shift(),
+        })
+    }
+}
+
 fn default_piano_range() -> (u8, u8) {
     (21, 108)
 }
@@ -266,4 +287,8 @@ fn default_color_schema() -> Vec<ColorSchemaV1> {
 
 fn default_output() -> Option<String> {
     Some("Buildin Synth".into())
+}
+
+fn default_octave_shift() -> u8 {
+    5
 }

--- a/neothesia/src/scene/mod.rs
+++ b/neothesia/src/scene/mod.rs
@@ -11,7 +11,7 @@ use std::{collections::HashMap, time::Duration};
 use winit::{
     dpi::{LogicalPosition, LogicalSize},
     event::{ElementState, KeyEvent, WindowEvent},
-    keyboard::Key,
+    keyboard::{KeyCode, PhysicalKey},
 };
 
 pub trait Scene {
@@ -26,7 +26,7 @@ pub fn handle_pc_keyboard_to_midi_event(ctx: &mut Context, event: &WindowEvent) 
         event:
             KeyEvent {
                 state,
-                logical_key: Key::Character(ch),
+                physical_key: PhysicalKey::Code(key_code),
                 repeat: false,
                 ..
             },
@@ -36,31 +36,40 @@ pub fn handle_pc_keyboard_to_midi_event(ctx: &mut Context, event: &WindowEvent) 
         return;
     };
 
-    let mut note: u8 = match ch.as_str() {
-        "a" => 0,
-        "w" => 1,
-        "s" => 2,
-        "e" => 3,
-        "d" => 4,
-        "f" => 5,
-        "t" => 6,
-        "g" => 7,
-        "y" => 8,
-        "h" => 9,
-        "u" => 10,
-        "j" => 11,
-        "k" => 12,
-        "o" => 13,
-        "l" => 14,
-        "p" => 15,
-        ";" => 16,
-        "'" => 17,
+    if *state == ElementState::Pressed {
+        match key_code {
+            KeyCode::KeyZ => ctx.config.pc_keyboard_shift_octave_down(),
+            KeyCode::KeyX => ctx.config.pc_keyboard_shift_octave_up(),
+            _ => {}
+        }
+    }
+
+    let mut note = match key_code {
+        KeyCode::KeyA => 0,
+        KeyCode::KeyW => 1,
+        KeyCode::KeyS => 2,
+        KeyCode::KeyE => 3,
+        KeyCode::KeyD => 4,
+        KeyCode::KeyF => 5,
+        KeyCode::KeyT => 6,
+        KeyCode::KeyG => 7,
+        KeyCode::KeyY => 8,
+        KeyCode::KeyH => 9,
+        KeyCode::KeyU => 10,
+        KeyCode::KeyJ => 11,
+        KeyCode::KeyK => 12,
+        KeyCode::KeyO => 13,
+        KeyCode::KeyL => 14,
+        KeyCode::KeyP => 15,
+        KeyCode::Semicolon => 16,
+        KeyCode::Quote => 17,
         _ => return,
     };
 
-    note += 21; // Start of 88 keyboard
-    note += 3; // Offset to C
-    note += 12 * 3; // Move 3oct up
+    note += 12 * ctx.config.pc_keyboard_octave();
+    if note > 127 {
+        return;
+    }
 
     let message = match state {
         ElementState::Pressed => MidiMessage::NoteOn {


### PR DESCRIPTION
- <kbd>z</kbd> <kbd>x</kbd> Can now shift PcKeyboard octave
- The octave shift is saved in the config
- While at it the key handling was changed to be keyboard layout independent