### PR TITLE
fix(nix): add ffmpeg libs to runtime dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /out
 .DS_Store
 node_modules
+
+# nix build output path
+/result

--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,7 @@
           pkgs.pkg-config
           pkgs.ffmpeg_8.dev
         ];
+        buildInputs = [pkgs.ffmpeg_8.lib];
         meta.mainProgram = "neothesia-cli";
         src = workspace;
       };


### PR DESCRIPTION
i believe ffmpeg's dynamically linked libraries can't be _found_ on linux without this. didn't test tho